### PR TITLE
Fix copilot feedback from PR #19

### DIFF
--- a/components/RideTitle.tsx
+++ b/components/RideTitle.tsx
@@ -51,7 +51,7 @@ const RideTitle: FC<Props> = ({ icon, className }) => (
       >
         Slovenia
       </Link>
-      <Link href={`/tags/ride/slovenia/gallery`}>
+      <Link href={`/tags/ride/slovenia/gallery`} className="mr-2">
         <BookImage className="ride-title-icon" />
       </Link>
     </h3>

--- a/scripts/country-utils.ts
+++ b/scripts/country-utils.ts
@@ -1,0 +1,44 @@
+// Country boundary utilities for geographic filtering
+
+export interface CountryBounds {
+  minLat: number
+  maxLat: number
+  minLng: number
+  maxLng: number
+}
+
+export const COUNTRY_BOUNDS: Record<string, CountryBounds> = {
+  NETHERLANDS: {
+    minLat: 50.75, // Southern border
+    maxLat: 53.7, // Northern border
+    minLng: 3.2, // Western border
+    maxLng: 7.2 // Eastern border
+  },
+  SLOVENIA: {
+    minLat: 45.4, // Southern border
+    maxLat: 46.9, // Northern border
+    minLng: 13.4, // Western border
+    maxLng: 16.6 // Eastern border
+  }
+}
+
+export function isInCountryBounds(
+  lat: number,
+  lng: number,
+  bounds: CountryBounds
+): boolean {
+  return (
+    lat >= bounds.minLat &&
+    lat <= bounds.maxLat &&
+    lng >= bounds.minLng &&
+    lng <= bounds.maxLng
+  )
+}
+
+export function isInNetherlands(lat: number, lng: number): boolean {
+  return isInCountryBounds(lat, lng, COUNTRY_BOUNDS.NETHERLANDS)
+}
+
+export function isInSlovenia(lat: number, lng: number): boolean {
+  return isInCountryBounds(lat, lng, COUNTRY_BOUNDS.SLOVENIA)
+}

--- a/scripts/load-netherlands-activities.ts
+++ b/scripts/load-netherlands-activities.ts
@@ -4,24 +4,7 @@ import fs from 'fs/promises'
 
 import { COUNTRY_NETHERLANDS, getCountryActivities } from './constTypes'
 import { getActivities, getLatLngs } from './strava'
-
-// Netherlands geographic bounds
-const NETHERLANDS_BOUNDS = {
-  minLat: 50.75, // Southern border
-  maxLat: 53.7, // Northern border
-  minLng: 3.2, // Western border
-  maxLng: 7.2 // Eastern border
-}
-
-// Check if coordinates are within Netherlands bounds
-function isInNetherlands(lat: number, lng: number): boolean {
-  return (
-    lat >= NETHERLANDS_BOUNDS.minLat &&
-    lat <= NETHERLANDS_BOUNDS.maxLat &&
-    lng >= NETHERLANDS_BOUNDS.minLng &&
-    lng <= NETHERLANDS_BOUNDS.maxLng
-  )
-}
+import { isInNetherlands } from './country-utils'
 
 async function getNetherlandsRides() {
   const activities = await getActivities()

--- a/scripts/load-slovenia-activities.ts
+++ b/scripts/load-slovenia-activities.ts
@@ -4,24 +4,7 @@ import fs from 'fs/promises'
 
 import { COUNTRY_SLOVENIA, getCountryActivities } from './constTypes'
 import { getActivities, getLatLngs } from './strava'
-
-// Slovenia geographic bounds
-const SLOVENIA_BOUNDS = {
-  minLat: 45.4, // Southern border
-  maxLat: 46.9, // Northern border
-  minLng: 13.4, // Western border
-  maxLng: 16.6 // Eastern border
-}
-
-// Check if coordinates are within Slovenia bounds
-function isInSlovenia(lat: number, lng: number): boolean {
-  return (
-    lat >= SLOVENIA_BOUNDS.minLat &&
-    lat <= SLOVENIA_BOUNDS.maxLat &&
-    lng >= SLOVENIA_BOUNDS.minLng &&
-    lng <= SLOVENIA_BOUNDS.maxLng
-  )
-}
+import { isInSlovenia } from './country-utils'
 
 async function getSloveniaRides() {
   const activities = await getActivities()

--- a/scripts/strava.ts
+++ b/scripts/strava.ts
@@ -1,11 +1,7 @@
 import axios, { isAxiosError } from 'axios'
 import fs from 'fs/promises'
-import { exec } from 'child_process'
-import { promisify } from 'util'
 
 import { Activity, Country, getCountryStreamPath, Streams } from './constTypes'
-
-const execAsync = promisify(exec)
 
 interface TokenResponse {
   access_token: string


### PR DESCRIPTION
## Summary
- Remove unused imports `exec` and `execAsync` from `scripts/strava.ts`
- Add consistent `mr-2` className to Slovenia gallery link in `components/RideTitle.tsx`
- Extract country boundary checks into shared utility `scripts/country-utils.ts`
- Update Netherlands and Slovenia activity loaders to use shared utility

## Test plan
- [ ] Verify unused imports are removed and code still compiles
- [ ] Check Slovenia gallery link has consistent spacing with other links
- [ ] Confirm country boundary utilities work correctly for both Netherlands and Slovenia
- [ ] Test that activity loading scripts still function properly

🤖 Generated with [Claude Code](https://claude.ai/code)