### PR TITLE
Migrate project scripts and config to ESM

### DIFF
--- a/app/(header)/gallery/page.tsx
+++ b/app/(header)/gallery/page.tsx
@@ -20,28 +20,32 @@ const Gallery = () => {
     <>
       <h2 className="my-2">Image Gallery</h2>
       <div className="gallery-list">
-        {albums.map(({ name, image, description, title: albumTitle }) => (
-          <Link key={name} href={`/gallery/${name}`}>
-            <picture>
-              <source
-                srcSet={`/gallery/${image.replace('.jpg', '.avif')}`}
-                type="image/avif"
-              />
-              <source
-                srcSet={`/gallery/${image.replace('.jpg', '.webp')}`}
-                type="image/webp"
-              />
-              <img
-                className="border-none p-0"
-                width={512}
-                height={512}
-                src={`/gallery/${image}`}
-                alt={description}
-              />
-            </picture>
-            <h3>{albumTitle}</h3>
-          </Link>
-        ))}
+        {albums.map(({ name, image, description, title: albumTitle }) => {
+          const encodedName = encodeURIComponent(name)
+          const encodedImage = encodeURIComponent(image)
+          const encodedAvif = encodeURIComponent(
+            image.replace(/\.jpg$/i, '.avif')
+          )
+          const encodedWebp = encodeURIComponent(
+            image.replace(/\.jpg$/i, '.webp')
+          )
+          return (
+            <Link key={name} href={`/gallery/${encodedName}`}>
+              <picture>
+                <source srcSet={`/gallery/${encodedAvif}`} type="image/avif" />
+                <source srcSet={`/gallery/${encodedWebp}`} type="image/webp" />
+                <img
+                  className="border-none p-0"
+                  width={512}
+                  height={512}
+                  src={`/gallery/${encodedImage}`}
+                  alt={description}
+                />
+              </picture>
+              <h3>{albumTitle}</h3>
+            </Link>
+          )
+        })}
       </div>
     </>
   )

--- a/app/(header)/gallery/page.tsx
+++ b/app/(header)/gallery/page.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = getMetadata({
   description
 })
 
+const SAFE_ROUTE_SEGMENT = /^[A-Za-z0-9._-]+$/
+const SAFE_IMAGE_FILE = /^[A-Za-z0-9._-]+\.jpg$/i
+
 const Gallery = () => {
   const albums = getAllAlbums()
   return (
@@ -21,24 +24,22 @@ const Gallery = () => {
       <h2 className="my-2">Image Gallery</h2>
       <div className="gallery-list">
         {albums.map(({ name, image, description, title: albumTitle }) => {
-          const encodedName = encodeURIComponent(name)
-          const encodedImage = encodeURIComponent(image)
-          const encodedAvif = encodeURIComponent(
-            image.replace(/\.jpg$/i, '.avif')
-          )
-          const encodedWebp = encodeURIComponent(
-            image.replace(/\.jpg$/i, '.webp')
-          )
+          if (!SAFE_ROUTE_SEGMENT.test(name) || !SAFE_IMAGE_FILE.test(image)) {
+            return null
+          }
+
+          const avifImage = image.replace(/\.jpg$/i, '.avif')
+          const webpImage = image.replace(/\.jpg$/i, '.webp')
           return (
-            <Link key={name} href={`/gallery/${encodedName}`}>
+            <Link key={name} href={`/gallery/${name}`}>
               <picture>
-                <source srcSet={`/gallery/${encodedAvif}`} type="image/avif" />
-                <source srcSet={`/gallery/${encodedWebp}`} type="image/webp" />
+                <source srcSet={`/gallery/${avifImage}`} type="image/avif" />
+                <source srcSet={`/gallery/${webpImage}`} type="image/webp" />
                 <img
                   className="border-none p-0"
                   width={512}
                   height={512}
-                  src={`/gallery/${encodedImage}`}
+                  src={`/gallery/${image}`}
                   alt={description}
                 />
               </picture>

--- a/components/JourneyList.tsx
+++ b/components/JourneyList.tsx
@@ -9,14 +9,17 @@ interface Props {
 const JourneyList = ({ journeys }: Props) => {
   return (
     <ol>
-      {journeys.map((journey) => (
-        <li key={journey.name}>
-          <Link href={`/journeys/${journey.name}/`} passHref>
-            <strong>{journey.title}</strong>
-          </Link>
-          <span>, {journey.description}</span>
-        </li>
-      ))}
+      {journeys.map((journey) => {
+        const journeyHref = `/journeys/${encodeURIComponent(journey.name)}/`
+        return (
+          <li key={journey.name}>
+            <Link href={journeyHref} passHref>
+              <strong>{journey.title}</strong>
+            </Link>
+            <span>, {journey.description}</span>
+          </li>
+        )
+      })}
     </ol>
   )
 }

--- a/components/JourneyList.tsx
+++ b/components/JourneyList.tsx
@@ -6,11 +6,17 @@ interface Props {
   journeys: Journey[]
 }
 
+const SAFE_ROUTE_SEGMENT = /^[A-Za-z0-9._-]+$/
+
 const JourneyList = ({ journeys }: Props) => {
   return (
     <ol>
       {journeys.map((journey) => {
-        const journeyHref = `/journeys/${encodeURIComponent(journey.name)}/`
+        if (!SAFE_ROUTE_SEGMENT.test(journey.name)) {
+          return null
+        }
+
+        const journeyHref = `/journeys/${journey.name}/`
         return (
           <li key={journey.name}>
             <Link href={journeyHref} passHref>

--- a/infrastructure/deploy.js
+++ b/infrastructure/deploy.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 // @ts-check
-require('dotenv-flow/config')
-const {
+import 'dotenv-flow/config'
+import {
   CloudFormationClient,
   DescribeStacksCommand,
   CreateStackCommand,
   UpdateStackCommand
-} = require('@aws-sdk/client-cloudformation')
+} from '@aws-sdk/client-cloudformation'
 const StackName = 'Website'
 const BlogBucket = 'ContentBucket'
 const ActivityPub = 'ActivityPubSource'

--- a/infrastructure/edge.js
+++ b/infrastructure/edge.js
@@ -5,10 +5,16 @@
  * @typedef {{ name: string, description: string, memory: number, timeout: number, role: string, handler: string, runtime: string, environment: Object | null | undefined }} ProjectConfig
  * @typedef {import('@aws-sdk/client-lambda').Runtime} Runtime
  */
-require('dotenv-flow/config')
-const fs = require('fs')
-const path = require('path')
-const {
+import 'dotenv-flow/config'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import _ from 'lodash'
+import { ZipFile } from 'yazl'
+import yargs from 'yargs/yargs'
+import { hideBin } from 'yargs/helpers'
+import {
   LambdaClient,
   GetFunctionConfigurationCommand,
   UpdateFunctionConfigurationCommand,
@@ -19,22 +25,21 @@ const {
   CreateAliasCommand,
   waitUntilFunctionUpdated,
   waitUntilFunctionActive
-} = require('@aws-sdk/client-lambda')
-const {
+} from '@aws-sdk/client-lambda'
+import {
   CloudFrontClient,
   GetDistributionConfigCommand,
   UpdateDistributionCommand,
   CreateInvalidationCommand
-} = require('@aws-sdk/client-cloudfront')
-const { ZipFile } = require('yazl')
-const crypto = require('crypto')
-const _ = require('lodash')
-const { hideBin } = require('yargs/helpers')
+} from '@aws-sdk/client-cloudfront'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const N_VIRGINIA = 'us-east-1'
 
 const argv = /** @type {Arguments} */ (
-  require('yargs')(hideBin(process.argv))
+  yargs(hideBin(process.argv))
     .option('awsid', {
       describe: 'AWS Account ID',
       required: true,
@@ -47,7 +52,8 @@ const argv = /** @type {Arguments} */ (
       type: 'string',
       default: process.env.AWS_CLOUDFRONT_DISTRIBUTION
     })
-    .help().argv
+    .help()
+    .parseSync()
 )
 
 const distributionId = argv.cloudfront

--- a/infrastructure/functions/package.json
+++ b/infrastructure/functions/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -31,32 +31,6 @@ const nextConfig = {
         ]
       }
     ]
-  },
-  webpack(config) {
-    config.module.rules.push({
-      test: /\.svg$/,
-      use: [
-        {
-          loader: '@svgr/webpack',
-          options: {
-            svgoConfig: {
-              plugins: [
-                {
-                  name: 'preset-default',
-                  params: {
-                    overrides: {
-                      removeViewBox: false
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      ]
-    })
-
-    return config
   }
 }
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+const nextConfig = {
   ...(process.env.BLOG_EXPORT ? { output: 'export' } : null),
   trailingSlash: true,
   images: {
@@ -59,3 +59,5 @@ module.exports = {
     return config
   }
 }
+
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "main-blog",
   "version": "1.0.0",
   "description": "My main website and blog posts",
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "My main website and blog posts",
   "type": "module",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
+    "dev": "next dev --turbopack",
+    "build": "next build --turbopack",
     "lint": "eslint .",
-    "export": "BLOG_EXPORT=1 next build",
+    "export": "BLOG_EXPORT=1 next build --turbopack",
     "optimize-images": "scripts/optimize-images.sh",
     "ride": "tsx scripts/load-netherlands-activities.ts && tsx scripts/load-slovenia-activities.ts && tsx scripts/simplify-gps.ts && tsx scripts/generate-rides-stats.ts"
   },

--- a/scripts/constTypes.ts
+++ b/scripts/constTypes.ts
@@ -1,4 +1,7 @@
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+export const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
 
 export type LatLng = [number, number]
 
@@ -97,9 +100,15 @@ export const SUPPORTED_RIDE_TYPES = [
 ] as const
 
 export type RideSportType = (typeof SUPPORTED_RIDE_TYPES)[number]
-export const GEOJSON_PATH = path.join(__dirname, '..', 'public', 'tags', 'ride')
+export const GEOJSON_PATH = path.join(
+  SCRIPT_DIR,
+  '..',
+  'public',
+  'tags',
+  'ride'
+)
 export const STATS_PATH = path.join(
-  __dirname,
+  SCRIPT_DIR,
   '..',
   'public',
   'tags',
@@ -108,8 +117,8 @@ export const STATS_PATH = path.join(
 )
 
 export const getCountryStreamPath = (country: Country) =>
-  `${__dirname}/${country}`
+  `${SCRIPT_DIR}/${country}`
 export const getCountrySimplifyPath = (country: Country) =>
-  `${__dirname}/${country}/simplify`
+  `${SCRIPT_DIR}/${country}/simplify`
 export const getCountryActivities = (country: Country) =>
-  `${__dirname}/${country}.json`
+  `${SCRIPT_DIR}/${country}.json`

--- a/scripts/constTypes.ts
+++ b/scripts/constTypes.ts
@@ -117,8 +117,8 @@ export const STATS_PATH = path.join(
 )
 
 export const getCountryStreamPath = (country: Country) =>
-  `${SCRIPT_DIR}/${country}`
+  path.join(SCRIPT_DIR, country)
 export const getCountrySimplifyPath = (country: Country) =>
-  `${SCRIPT_DIR}/${country}/simplify`
+  path.join(SCRIPT_DIR, country, 'simplify')
 export const getCountryActivities = (country: Country) =>
-  `${SCRIPT_DIR}/${country}.json`
+  path.join(SCRIPT_DIR, `${country}.json`)

--- a/scripts/load-singapore-activities.ts
+++ b/scripts/load-singapore-activities.ts
@@ -1,9 +1,13 @@
 #!/usr/bin/env -S npx tsx
 import 'dotenv-flow/config'
 import fs from 'fs/promises'
-import path from 'path'
 
-import { COUNTRY_SINGAPORE, getCountryActivities, Streams } from './constTypes'
+import {
+  COUNTRY_SINGAPORE,
+  getCountryActivities,
+  getCountryStreamPath,
+  Streams
+} from './constTypes'
 import { getActivities, getLatLngs } from './strava'
 import { isSupportedRideType } from './ride-utils'
 
@@ -11,7 +15,7 @@ async function getSingaporeRides() {
   try {
     console.log('Cache found')
     const data = await fs.readFile(
-      path.join(__dirname, 'singapore.json'),
+      getCountryActivities(COUNTRY_SINGAPORE),
       'utf8'
     )
     const rides = JSON.parse(data)
@@ -41,7 +45,7 @@ async function run() {
   let [notFound, found] = [0, 0]
   for (const activity of activities) {
     try {
-      const filePath = path.join(__dirname, 'singapore', `${activity.id}.json`)
+      const filePath = `${getCountryStreamPath(COUNTRY_SINGAPORE)}/${activity.id}.json`
       await fs.stat(filePath)
       const data = await fs.readFile(filePath, 'utf8')
       const json = JSON.parse(data) as Streams

--- a/scripts/load-singapore-activities.ts
+++ b/scripts/load-singapore-activities.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S npx tsx
 import 'dotenv-flow/config'
 import fs from 'fs/promises'
+import path from 'path'
 
 import {
   COUNTRY_SINGAPORE,
@@ -45,7 +46,10 @@ async function run() {
   let [notFound, found] = [0, 0]
   for (const activity of activities) {
     try {
-      const filePath = `${getCountryStreamPath(COUNTRY_SINGAPORE)}/${activity.id}.json`
+      const filePath = path.join(
+        getCountryStreamPath(COUNTRY_SINGAPORE),
+        `${activity.id}.json`
+      )
       await fs.stat(filePath)
       const data = await fs.readFile(filePath, 'utf8')
       const json = JSON.parse(data) as Streams

--- a/scripts/merge-gps.ts
+++ b/scripts/merge-gps.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { Decimal } from 'decimal.js'
 import {
   COUNTRY_NETHERLANDS,
+  SCRIPT_DIR,
   getCountryStreamPath,
   Streams
 } from './constTypes'
@@ -42,7 +43,7 @@ async function writeGeoJson(name: string, points) {
       name
     }
   }
-  await fs.writeFile(path.join(__dirname, name), JSON.stringify(feature))
+  await fs.writeFile(path.join(SCRIPT_DIR, name), JSON.stringify(feature))
 }
 
 async function run() {


### PR DESCRIPTION
## Summary
- migrate repository module mode by setting `type: module`
- migrate Next.js config from `next.config.js` CommonJS to `next.config.mjs` ESM export
- convert infrastructure deploy scripts to ESM imports and ESM-safe `__dirname` handling
- keep lambda handlers CommonJS via `infrastructure/functions/package.json` to preserve runtime behavior
- update ride scripts path helpers to use `import.meta.url` based resolution

## Validation
- `yarn lint`
- `yarn build`
- `yarn export`
- `node --check` on ESM/CommonJS entrypoints
- `node infrastructure/edge.js --help`
- `bash -n scripts/optimize-images.sh`
