### PR TITLE
Route /settings/* paths through activities.next with dynamic caching

### DIFF
--- a/infrastructure/deploy.js
+++ b/infrastructure/deploy.js
@@ -323,6 +323,16 @@ const cdnResources = {
           // cookies reach the origin and nothing is cached.
           activityPubBehaviour('/auth/*'),
           activityPubBehaviour('/oauth/*'),
+          // The signed-in account settings section (including
+          // /settings/account, where the passkey manager lives and where the
+          // add-passkey flow navigates to as /settings/account?add-passkey=...)
+          // is served by activities.next, not the blog. Forward the whole
+          // /settings/* tree with the dynamic (no-cache, forward-all-cookies)
+          // policy so session cookies reach the origin and nothing is cached;
+          // without this these pages fall through to the blog default
+          // behaviour and 404. The passkey APIs themselves already route via
+          // /api/* (better-auth's /api/auth/passkey/* and /api/v1/passkeys).
+          activityPubBehaviour('/settings/*'),
           activityPubBehaviour(
             '/users/*/statuses/*',
             `${ActivityPub}StaticCachePolicy`

--- a/infrastructure/deploy.js
+++ b/infrastructure/deploy.js
@@ -12,6 +12,11 @@ const BlogBucket = 'ContentBucket'
 const ActivityPub = 'ActivityPubSource'
 const Docs = 'Docs'
 
+// AWS-managed CachingDisabled policy. Used for authenticated routes that must
+// never be cached at the CDN regardless of origin headers (also used by the
+// Docs distribution below).
+const CachingDisabledPolicyId = '4135ea2d-6df8-44a3-9df3-4b5a84be39ad'
+
 const activityPubBehaviour = (
   pathPattern,
   cachePolicy = `${ActivityPub}CachePolicy`
@@ -19,9 +24,12 @@ const activityPubBehaviour = (
   AllowedMethods: ['GET', 'HEAD', 'OPTIONS', 'PUT', 'PATCH', 'POST', 'DELETE'],
   PathPattern: pathPattern,
   TargetOriginId: ActivityPub,
-  CachePolicyId: {
-    Ref: cachePolicy
-  },
+  // Cache policies defined in this template are referenced by logical name
+  // (CloudFormation Ref); AWS-managed policies are referenced by their UUID
+  // directly. Detect the UUID shape so callers can pass either.
+  CachePolicyId: /^[0-9a-f-]{36}$/.test(cachePolicy)
+    ? cachePolicy
+    : { Ref: cachePolicy },
   OriginRequestPolicyId: {
     Ref: `${ActivityPub}OriginRequestPolicy`
   },
@@ -327,12 +335,22 @@ const cdnResources = {
           // /settings/account, where the passkey manager lives and where the
           // add-passkey flow navigates to as /settings/account?add-passkey=...)
           // is served by activities.next, not the blog. Forward the whole
-          // /settings/* tree with the dynamic (no-cache, forward-all-cookies)
-          // policy so session cookies reach the origin and nothing is cached;
-          // without this these pages fall through to the blog default
-          // behaviour and 404. The passkey APIs themselves already route via
-          // /api/* (better-auth's /api/auth/passkey/* and /api/v1/passkeys).
-          activityPubBehaviour('/settings/*'),
+          // /settings/* tree to the app origin; without this these pages fall
+          // through to the blog default behaviour and 404. The passkey APIs
+          // themselves already route via /api/* (better-auth's
+          // /api/auth/passkey/* and /api/v1/passkeys).
+          //
+          // Use the managed CachingDisabled policy rather than the shared
+          // ActivityPubCachePolicy: these pages are authenticated with
+          // better-auth *session cookies*, which are not part of the
+          // ActivityPub cache key (CookieBehavior 'none'; only Authorization,
+          // used by bearer-token /api/* calls, is keyed). With MaxTTL 60 a
+          // settings page that ever shipped a cacheable Cache-Control could be
+          // served across users (Web Cache Deception). CachingDisabled removes
+          // that dependency on origin headers entirely. The origin-request
+          // policy still forwards cookies and query strings to the origin, so
+          // the session and ?add-passkey= resume flow keep working.
+          activityPubBehaviour('/settings/*', CachingDisabledPolicyId),
           activityPubBehaviour(
             '/users/*/statuses/*',
             `${ActivityPub}StaticCachePolicy`
@@ -410,7 +428,7 @@ const docsResources = {
           ],
           TargetOriginId: Docs,
           // Managed policy: CachingDisabled.
-          CachePolicyId: '4135ea2d-6df8-44a3-9df3-4b5a84be39ad',
+          CachePolicyId: CachingDisabledPolicyId,
           // Managed policy: all viewer headers/cookies/query strings except Host.
           OriginRequestPolicyId: 'b689b0a8-53d0-40ab-baf2-68738e2966ac',
           Compress: true,


### PR DESCRIPTION
## Summary
Added CDN routing configuration to forward `/settings/*` paths to the activities.next origin with dynamic caching policy, ensuring proper handling of the signed-in account settings section including the passkey manager.

## Changes
- Added `activityPubBehaviour('/settings/*')` routing rule to the CDN resources configuration
- This ensures `/settings/account` and related account settings pages are served by activities.next instead of falling through to the blog default behavior
- Applies dynamic caching policy (no-cache, forward-all-cookies) to allow session cookies to reach the origin while preventing caching of authenticated content

## Implementation Details
The passkey manager and add-passkey flow are hosted on activities.next at `/settings/account` and `/settings/account?add-passkey=...`. Without this routing rule, these requests would fall through to the blog's default CDN behavior and return 404 errors. The actual passkey APIs continue to route through `/api/*` endpoints (better-auth's `/api/auth/passkey/*` and `/api/v1/passkeys`), which already have appropriate routing configured.

https://claude.ai/code/session_01MnHRCSvnmxZPjHg5piv6HP