### PR TITLE
Fix map lifecycle, gallery loading and script failure handling

### DIFF
--- a/app/(header)/layout.tsx
+++ b/app/(header)/layout.tsx
@@ -34,7 +34,7 @@ const RootLayout = ({ children }: Props) => {
     <html lang="en" suppressHydrationWarning>
       <body>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-          <div className="layout-div">
+          <div id="app-root" className="layout-div">
             <Header title={title} url={url} />
             <main className="main-container">{children}</main>
           </div>

--- a/app/(noheader)/journeys/airtag-sg-th/AirTagMap.tsx
+++ b/app/(noheader)/journeys/airtag-sg-th/AirTagMap.tsx
@@ -7,12 +7,15 @@ import 'mapbox-gl/dist/mapbox-gl.css'
 
 import { MAPBOX_PUBLIC_KEY } from '../../../../libs/config'
 
+mapboxgl.accessToken = MAPBOX_PUBLIC_KEY
+
 export const AirTagMap = () => {
   const mapEl = useRef<HTMLDivElement>(null)
 
-  mapboxgl.accessToken = MAPBOX_PUBLIC_KEY
-
   useEffect(() => {
+    const element = mapEl.current
+    if (!element) return
+
     const zoomLevel = (height?: number) => {
       switch (height) {
         case 250:
@@ -25,10 +28,10 @@ export const AirTagMap = () => {
     }
 
     const map = new mapboxgl.Map({
-      container: 'map',
+      container: element,
       style: 'mapbox://styles/mapbox/streets-v11',
       center: [102.2949, 7.7051],
-      zoom: zoomLevel(mapEl?.current?.offsetHeight),
+      zoom: zoomLevel(element.offsetHeight),
       minZoom: 5
     })
     map.on('load', () => {
@@ -101,7 +104,8 @@ export const AirTagMap = () => {
         }
       })
     })
+    return () => map.remove()
   }, [])
 
-  return <div ref={mapEl} id="map" className="map mb-4" />
+  return <div ref={mapEl} className="map mb-4" />
 }

--- a/app/(noheader)/journeys/wordle/CopierIcon.tsx
+++ b/app/(noheader)/journeys/wordle/CopierIcon.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { FC, useEffect } from 'react'
+import React, { FC, useCallback, useEffect } from 'react'
 import { Copy } from 'lucide-react'
 
 import { Result } from '../../../../libs/wordle'
@@ -12,14 +12,22 @@ interface Props {
 }
 
 export const CopierIcon: FC<Props> = ({ result, className }) => {
+  const copyResult = useCallback(() => {
+    setResultToClipboard(result).catch((error) => {
+      // Rejected without a user gesture, or when ClipboardItem is unavailable
+      console.warn('Unable to copy wordle result', error)
+    })
+  }, [result])
+
   useEffect(() => {
-    setResultToClipboard(result)
-  })
+    copyResult()
+  }, [copyResult])
+
   return (
     <span
       className={`cursor-pointer ${className}`}
       title="Copy"
-      onClick={() => setResultToClipboard(result)}
+      onClick={copyResult}
     >
       <Copy className="w-5 h-5 inline" />
     </span>

--- a/app/(noheader)/posts/[...segment]/page.tsx
+++ b/app/(noheader)/posts/[...segment]/page.tsx
@@ -10,7 +10,7 @@ import { ThemeToggle } from '../../../../components/ThemeToggle'
 import { getMetadata } from '../../../../components/Meta'
 import { getAllPosts, getConfig, parsePost } from '../../../../libs/blog'
 
-const getPost = (segment: string) => {
+const getPost = (segment: string[]) => {
   const config = getConfig()
   const contentPath = path.join(
     process.cwd(),
@@ -23,7 +23,7 @@ const getPost = (segment: string) => {
 }
 
 interface Props {
-  params: Promise<{ segment: string }>
+  params: Promise<{ segment: string[] }>
 }
 
 export const generateStaticParams = async () => {

--- a/app/api/apple/route.ts
+++ b/app/api/apple/route.ts
@@ -13,6 +13,7 @@ const getHeaders = (request: NextRequest) => {
   if (process.env.NODE_ENV !== 'production') {
     return {
       'Access-Control-Allow-Origin': '*',
+      Vary: 'Origin',
       'Content-Type': 'application/json',
       'Cache-Control': 's-maxage=1, stale-while-revalidate=30'
     }
@@ -22,6 +23,7 @@ const getHeaders = (request: NextRequest) => {
   if (!ALLOW_ORIGINS.includes(origin)) {
     return {
       'Access-Control-Allow-Origin': 'https://www.llun.me',
+      Vary: 'Origin',
       'Content-Type': 'application/json',
       'Cache-Control': 's-maxage=1, stale-while-revalidate=30'
     }
@@ -29,16 +31,34 @@ const getHeaders = (request: NextRequest) => {
 
   return {
     'Access-Control-Allow-Origin': origin,
+    Vary: 'Origin',
     'Content-Type': 'application/json',
     'Cache-Control': 's-maxage=3600, stale-while-revalidate=3600'
   }
 }
 
-export async function POST(request: NextRequest) {
-  const body = (await request.json()) as AssetsRequest
+const ParseError = Symbol('ParseError')
 
+const parseBody = async (request: NextRequest) => {
+  try {
+    return (await request.json()) as AssetsRequest
+  } catch {
+    return ParseError
+  }
+}
+
+export async function POST(request: NextRequest) {
   const headers = getHeaders(request)
-  if (!ALLOW_TOKEN_IDS.includes(body.token)) {
+
+  const body = await parseBody(request)
+  if (body === ParseError) {
+    return new Response(JSON.stringify({ error: 'Bad Request' }), {
+      status: 400,
+      headers
+    })
+  }
+
+  if (!ALLOW_TOKEN_IDS.includes(body?.token)) {
     return new Response(JSON.stringify({ error: 'Not Found' }), {
       status: 404,
       headers

--- a/components/Medias.tsx
+++ b/components/Medias.tsx
@@ -39,17 +39,26 @@ const Medias: FC<Props> = ({ partition, token, medias, className }) => {
     index: number
   }>()
   const photoDom = useRef<HTMLDivElement>(null)
+  const failedOffset = useRef<number | null>(null)
 
   useEffect(() => {
     setPhotoState(PhotoState.LOADING)
     const firstBatch = medias.slice(0, BatchSize * 2)
-    proxyAssetsUrl(partition, token, firstBatch).then((assets) => {
-      if (!assets) return
+    proxyAssetsUrl(partition, token, firstBatch)
+      .then((assets) => {
+        if (!assets) {
+          setPhotoState(PhotoState.IDLE)
+          return
+        }
 
-      setPhotoState(PhotoState.IDLE)
-      mergeMediaAssets(firstBatch, assets)
-      setPhotos(firstBatch)
-    })
+        setPhotoState(PhotoState.IDLE)
+        mergeMediaAssets(firstBatch, assets)
+        setPhotos(firstBatch)
+      })
+      .catch((error) => {
+        console.error(error)
+        setPhotoState(PhotoState.IDLE)
+      })
   }, [partition, token, medias])
 
   useEffect(() => {
@@ -57,19 +66,34 @@ const Medias: FC<Props> = ({ partition, token, medias, className }) => {
 
     const intersectionObserver = new IntersectionObserver(async (entries) => {
       const entry = entries[0]
-      if (entry.isIntersecting && canLoadPhoto(medias, photos, photoState)) {
-        // Load next batch
-        setPhotoState(PhotoState.LOADING)
-        const next = medias.slice(photos.length, photos.length + BatchSize)
+      if (!entry.isIntersecting) {
+        failedOffset.current = null
+        return
+      }
+      // Releasing the state back to IDLE re-runs this effect and the fresh
+      // observer fires again on the still-visible sentinel, so a batch that
+      // failed is only retried once the sentinel leaves and re-enters view
+      if (failedOffset.current === photos.length) return
+      if (!canLoadPhoto(medias, photos, photoState)) return
+
+      // Load next batch
+      setPhotoState(PhotoState.LOADING)
+      const next = medias.slice(photos.length, photos.length + BatchSize)
+      try {
         const assets = await proxyAssetsUrl(partition, token, next)
         if (!assets) {
-          // setPhotoState(PhotoState.IDLE)
+          failedOffset.current = photos.length
+          setPhotoState(PhotoState.IDLE)
           return
         }
 
         setPhotoState(PhotoState.IDLE)
         mergeMediaAssets(next, assets)
         setPhotos([...photos, ...next])
+      } catch (error) {
+        console.error(error)
+        failedOffset.current = photos.length
+        setPhotoState(PhotoState.IDLE)
       }
     })
     intersectionObserver.observe(photoDom.current)
@@ -79,7 +103,7 @@ const Medias: FC<Props> = ({ partition, token, medias, className }) => {
   if (!photos.length) return null
 
   return (
-    <div className={`ride-medias ${className}`}>
+    <div className={cn('ride-medias', className)}>
       <MediaModal
         isOpen={!!selectedMedia}
         media={selectedMedia?.media}

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import ReactModal from 'react-modal'
 
 export const Modal = () => {
   useEffect(() => {
-    ReactModal.setAppElement('#__modal')
-  })
+    ReactModal.setAppElement('#app-root')
+  }, [])
 
-  return <div id="__modal" />
+  return null
 }

--- a/components/RideMap.tsx
+++ b/components/RideMap.tsx
@@ -1,12 +1,19 @@
 'use client'
 
+import cn from 'classnames'
 import mapboxgl, { Map } from 'mapbox-gl'
+import { useTheme } from 'next-themes'
 import React, { FC, useEffect, useRef } from 'react'
 
 import { MAPBOX_PUBLIC_KEY } from '@/libs/config'
 
 import 'mapbox-gl/dist/mapbox-gl.css'
 import { YoutubeVideo } from './RideVideos'
+
+mapboxgl.accessToken = MAPBOX_PUBLIC_KEY
+
+const LIGHT_STYLE = 'mapbox://styles/mapbox/light-v10'
+const DARK_STYLE = 'mapbox://styles/mapbox/dark-v11'
 
 interface Props {
   className?: string
@@ -30,10 +37,18 @@ const RideMap: FC<Props> = ({
   videos
 }) => {
   const mapEl = useRef<HTMLDivElement>(null)
-  mapboxgl.accessToken = MAPBOX_PUBLIC_KEY
+  const { resolvedTheme } = useTheme()
 
   const [mobile, tablet, desktop] = zoomLevels
+  const [longitude, latitude] = center
+  const videosKey = JSON.stringify(videos)
+
   useEffect(() => {
+    const element = mapEl.current
+    if (!element) return
+
+    const markers = JSON.parse(videosKey) as YoutubeVideo[]
+
     const zoomLevel = (height?: number) => {
       switch (height) {
         case 250:
@@ -45,10 +60,10 @@ const RideMap: FC<Props> = ({
       }
     }
     const map = new mapboxgl.Map({
-      container: 'map',
-      style: 'mapbox://styles/mapbox/light-v10',
-      zoom: zoomLevel(mapEl?.current?.offsetHeight),
-      center,
+      container: element,
+      style: resolvedTheme === 'dark' ? DARK_STYLE : LIGHT_STYLE,
+      zoom: zoomLevel(element.offsetHeight),
+      center: [longitude, latitude],
       minZoom,
       maxZoom
     })
@@ -70,10 +85,11 @@ const RideMap: FC<Props> = ({
           'line-width': 2
         }
       })
-      for (const video of videos) {
+      for (const video of markers) {
         const link = document.createElement('a')
         link.href = video.url
         link.target = '_blank'
+        link.rel = 'noopener noreferrer'
 
         const container = document.createElement('div')
         container.className = 'ride-map-marker-container'
@@ -96,9 +112,21 @@ const RideMap: FC<Props> = ({
         })
       }
     })
-  })
+    return () => map.remove()
+  }, [
+    mobile,
+    tablet,
+    desktop,
+    longitude,
+    latitude,
+    minZoom,
+    maxZoom,
+    dataPath,
+    videosKey,
+    resolvedTheme
+  ])
 
-  return <div ref={mapEl} id="map" className={`ride-map ${className}`} />
+  return <div ref={mapEl} className={cn('ride-map', className)} />
 }
 
 export default RideMap

--- a/components/RideStats.tsx
+++ b/components/RideStats.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames'
 import React, { FC } from 'react'
 
 interface Stats {
@@ -11,7 +12,7 @@ interface Props {
 }
 
 const RideStats: FC<Props> = ({ stats, className }) => (
-  <section className={`ride-stats ${className}`}>
+  <section className={cn('ride-stats', className)}>
     <div className="ride-stats-card">
       <h2>Total Rides</h2>
       <p>{new Intl.NumberFormat('en').format(stats.activities)} Rides</p>

--- a/components/RideTitle.tsx
+++ b/components/RideTitle.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames'
 import Image from 'next/image'
 import Link from 'next/link'
 import React, { FC } from 'react'
@@ -15,7 +16,7 @@ const COUNTRIES = [
 ] as const
 
 const RideTitle: FC<Props> = ({ icon, className }) => (
-  <section className={`flex flex-col ${className}`}>
+  <section className={cn('flex flex-col', className)}>
     <h3 className="flex-1">
       {icon && (
         <Image

--- a/infrastructure/edge.js
+++ b/infrastructure/edge.js
@@ -260,7 +260,7 @@ async function deploy(functionName) {
       version = latestVersion.Version
     }
   } catch (error) {
-    if (error.code !== 'ResourceNotFoundException') {
+    if (error.name !== 'ResourceNotFoundException') {
       throw error
     }
     const [digest, content] = await archivingFunction(functionName)
@@ -403,4 +403,5 @@ run()
   .catch((error) => {
     console.error(error.message)
     console.error(error.stack)
+    process.exit(-1)
   })

--- a/libs/gallery.ts
+++ b/libs/gallery.ts
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon'
 import path from 'path'
 import yaml from 'yaml'
 
-import { getMediaList } from './apple/media'
+import { Media, getMediaList } from './apple/media'
 import { fetchStream } from './apple/webstream'
 import { Config, getConfig } from './blog'
 import { getMarkdown } from './markdown'
@@ -91,7 +91,13 @@ export const getAllAlbums = memoize(() => {
   return albums
 })
 
-export const getAlbum = memoize(async (name: string) => {
+export interface AlbumMedias {
+  album: Album
+  medias: Media[]
+  partition: number
+}
+
+const loadAlbum = async (name: string): Promise<AlbumMedias | null> => {
   const config = getConfig()
   const base = path.join(process.cwd(), 'contents', 'galleries')
   const file = path.join(base, `${name}.md`)
@@ -112,4 +118,12 @@ export const getAlbum = memoize(async (name: string) => {
     medias,
     partition: stream?.partition ?? 0
   }
+}
+
+export const getAlbum = memoize((name: string): Promise<AlbumMedias | null> => {
+  const promise = loadAlbum(name)
+  promise.catch(() => {
+    getAlbum.cache.delete(name)
+  })
+  return promise
 })

--- a/scripts/generate-rides-stats.ts
+++ b/scripts/generate-rides-stats.ts
@@ -78,7 +78,7 @@ async function run() {
 
 run()
   .then(() => console.log('done'))
-  .catch((e) => {
-    console.error(e.message)
-    console.error(e.stack)
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
   })

--- a/scripts/load-netherlands-activities.ts
+++ b/scripts/load-netherlands-activities.ts
@@ -18,4 +18,7 @@ run()
   .then(() => {
     console.log('done')
   })
-  .catch((e) => console.error(e.message))
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })

--- a/scripts/load-singapore-activities.ts
+++ b/scripts/load-singapore-activities.ts
@@ -70,4 +70,7 @@ run()
   .then(() => {
     console.log('done')
   })
-  .catch((e) => console.error(e.message))
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })

--- a/scripts/load-slovenia-activities.ts
+++ b/scripts/load-slovenia-activities.ts
@@ -18,4 +18,7 @@ run()
   .then(() => {
     console.log('done')
   })
-  .catch((e) => console.error(e.message))
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })

--- a/scripts/simplify-gps.ts
+++ b/scripts/simplify-gps.ts
@@ -82,7 +82,7 @@ function removeNearbyPoints(
 async function simplifyCountry(country: Country) {
   const simplifyPath = getCountrySimplifyPath(country)
   await fs.mkdir(simplifyPath, { recursive: true })
-  const files = await fs.readdir(getCountryStreamPath(country))
+  const files = (await fs.readdir(getCountryStreamPath(country))).sort()
 
   const features: Feature[] = []
   const processedFiles: string[] = []
@@ -163,7 +163,7 @@ async function run() {
 
 run()
   .then(() => console.log('\n=== OPTIMIZATION COMPLETE ==='))
-  .catch((e) => {
-    console.error(e.message)
-    console.error(e.stack)
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
   })

--- a/scripts/strava.ts
+++ b/scripts/strava.ts
@@ -1,5 +1,6 @@
 import axios, { isAxiosError } from 'axios'
 import fs from 'fs/promises'
+import path from 'path'
 
 import { Activity, Country, getCountryStreamPath, Streams } from './constTypes'
 
@@ -7,6 +8,52 @@ interface TokenResponse {
   access_token: string
   refresh_token: string
   expires_at: number
+}
+
+// Axios attaches the request config and the raw request to every error, so
+// logging one whole would print the Bearer token and the OAuth client secret.
+// error.config is the same object as error.response.config, so scrubbing it
+// once covers both.
+function redactAxiosError(error: unknown) {
+  if (!isAxiosError(error)) return error
+  if (error.config) {
+    const headers = error.config.headers as Record<string, unknown>
+    for (const key of Object.keys(headers ?? {})) {
+      if (key.toLowerCase() === 'authorization') delete headers[key]
+    }
+    error.config.data = undefined
+  }
+  error.request = undefined
+  if (error.response) error.response.request = undefined
+  return error
+}
+
+async function writeEnvLocal(variables: Record<string, string>) {
+  const envFilePath = path.resolve(process.cwd(), '.env.local')
+
+  let content = ''
+  let created = false
+  try {
+    content = await fs.readFile(envFilePath, 'utf-8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    created = true
+  }
+
+  for (const [key, value] of Object.entries(variables)) {
+    const line = new RegExp(`^${key}=.*$`, 'm')
+    if (line.test(content)) {
+      content = content.replace(line, () => `${key}=${value}`)
+      continue
+    }
+    if (content.length > 0 && !content.endsWith('\n')) content += '\n'
+    content += `${key}=${value}\n`
+  }
+
+  await fs.writeFile(envFilePath, content, { encoding: 'utf-8', mode: 0o600 })
+  console.log(
+    `${created ? 'Created' : 'Updated'} ${envFilePath} with the new Strava tokens`
+  )
 }
 
 async function refreshAccessToken(): Promise<string> {
@@ -29,20 +76,12 @@ async function refreshAccessToken(): Promise<string> {
       }
     )
 
-    // Update .env.local file with new tokens using bash commands
-    const envFilePath = '.env.local';
-    let envContent = await fs.readFile(envFilePath, 'utf-8');
-
-    envContent = envContent.replace(
-      /STRAVA_TOKEN=.*/,
-      `STRAVA_TOKEN=${data.access_token}`
-    );
-    envContent = envContent.replace(
-      /STRAVA_REFRESH_TOKEN=.*/,
-      `STRAVA_REFRESH_TOKEN=${data.refresh_token}`
-    );
-
-    await fs.writeFile(envFilePath, envContent, 'utf-8');
+    // Strava rotates the refresh token on every use, the new one must be
+    // persisted or the next run has to re-authorise by hand
+    await writeEnvLocal({
+      STRAVA_TOKEN: data.access_token,
+      STRAVA_REFRESH_TOKEN: data.refresh_token
+    })
 
     // Update process.env for current session
     process.env.STRAVA_TOKEN = data.access_token
@@ -58,8 +97,8 @@ async function refreshAccessToken(): Promise<string> {
         `Rate limit hit on refreshing token. Usage: ${usage}, Limit: ${limit}`
       )
     }
-    console.error('Failed to refresh access token:', error)
-    throw error
+    console.error('Failed to refresh access token:', redactAxiosError(error))
+    throw redactAxiosError(error)
   }
 }
 
@@ -87,7 +126,7 @@ async function getValidAccessToken(): Promise<string> {
         console.error(
           `Rate limit hit on getting athlete. Usage: ${usage}, Limit: ${limit}`
         )
-        throw error
+        throw redactAxiosError(error)
       }
     }
     // Token is likely expired, refresh it
@@ -129,7 +168,7 @@ export async function getActivities(before?: number, loadAll = false) {
           `Rate limit hit on getting activities. Usage: ${usage}, Limit: ${limit}`
         )
       }
-      throw error
+      throw redactAxiosError(error)
     }
     await new Promise((resolve) => setTimeout(resolve, 1000))
   }
@@ -172,7 +211,7 @@ export async function getLatLngs(country: Country, activity: Activity) {
           `Rate limit hit on getting lat/lng for activity ${activity.id}. Usage: ${usage}, Limit: ${limit}`
         )
       }
-      throw error
+      throw redactAxiosError(error)
     }
   }
 }


### PR DESCRIPTION
First of four PRs from a full-codebase review. This one is **bug fixes only** — no dependency changes, no refactors, no accessibility work (those follow in PRs 2–4).

Every issue below was verified by reading the code, and each fix was checked by an independent adversarial review pass before landing.

## Components

**RideMap rebuilt the map on every render and never disposed it.** The effect had no dependency array and no cleanup, and passed `container: 'map'` (a DOM id) instead of its own ref — so every re-render constructed another `mapboxgl.Map` into the same div, stacking canvases, WebGL contexts, markers and `zoom` listeners. React Strict Mode doubled this on mount. It now builds once per genuine input change and calls `map.remove()` on cleanup. While in there, the basemap follows the active theme instead of always rendering `light-v10` in dark mode, and marker links get `rel="noopener noreferrer"`.

**AirTagMap had the same defect** (missing cleanup, id-based container). Not on the original review list — found while fixing RideMap, same bug, so it is fixed here too.

**Gallery infinite scroll wedged permanently after one failed request.** When `proxyAssetsUrl` returned `null` the loading state was never released, and the reset on the second path was sitting commented out. Since `canLoadPhoto` refuses to run while `LOADING`, one failure killed scrolling for the rest of the page view. The state is now always released — and because releasing it re-runs the effect and the fresh `IntersectionObserver` immediately re-fires on the still-visible sentinel, a failed offset is remembered so the naive fix does not turn a wedge into an unbounded retry loop against `/api/apple`.

**Modal aria-hiding did nothing.** `setAppElement('#__modal')` pointed at the component's own empty placeholder — a sibling of the real content — so page content was never hidden from assistive technology behind an open modal. It now targets the actual content wrapper. Verified in a browser: `#app-root` gains `aria-hidden="true"` while the modal is open and loses it on close.

**`class="ride-medias undefined"`** was rendering on gallery grids, because the optional `className` was interpolated into a template string. Fixed in `Medias`, `RideMap`, `RideStats` and `RideTitle` using the `classnames` helper already used elsewhere in these files.

**CopierIcon overwrote the clipboard on every render** — the effect had no dependency array, so simply re-rendering the page silently replaced the user's clipboard, and the rejection (routine without a user gesture) was unhandled.

## Routes and libs

- The posts catch-all typed its param as `string`; Next supplies `string[]`.
- `app/api/apple` varies `Access-Control-Allow-Origin` per request origin under `s-maxage=3600` but sent no `Vary: Origin`, so a shared cache could serve one origin's header to another. It also returned 500 instead of 400 on an unparseable body.
- `getAlbum` memoized rejected promises, so a single transient iCloud failure poisoned that album slug for the remainder of the build.

## Scripts and infrastructure

- **Every ride script swallowed failures and exited 0**, so the `yarn ride` `&&` chain marched on past a failed step. They now log the full error and set a non-zero exit code.
- **That change would have leaked secrets**, so axios errors are redacted first — a whole `AxiosError` dump contains the Bearer token and the OAuth client secret. Confirmed against real axios errors: the token is present before redaction and absent after, including lowercase header keys.
- **The `.env.local` rewrite could lose the rotated refresh token.** Strava rotates it on use, so when the regex silently no-opped the new token was gone and re-authorisation was needed by hand. It now replaces or appends, creating the file `0600` if absent.
- `simplify-gps` consumed `readdir` unsorted, making committed GeoJSON order machine-dependent and producing spurious whole-file diffs.
- `edge.js` tested `error.code` where AWS SDK v3 sets `error.name`, making the create-function bootstrap unreachable, and reported success to the shell on failure.

## Verification

`yarn lint`, `tsc`, and **both** deploy targets build clean — `yarn export` (S3 static) and `yarn build` (Vercel, which serves `/api/apple`). Scripts were typechecked separately since `tsconfig` does not currently cover them (fixed in PR 3).

Browser pass on the dev server, where Strict Mode makes the map bug reproducible:
- exactly **1** canvas in the map container on load, and still 1 after a theme switch (previously these stacked)
- `#app-root` correctly gains and loses `aria-hidden` around modal open/close
- no `undefined` in any rendered class attribute
- no unhandled promise rejections on the wordle page

🤖 Generated with [Claude Code](https://claude.com/claude-code)