### PR TITLE
Add CI gate, widen typecheck and fix deploy caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Lint, typecheck and build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Typecheck
+        run: yarn typecheck
+
+      - name: Build site
+        run: yarn export
+        # This secret lives in the production environment, which this job
+        # deliberately does not join, so it is empty on every pull request. The
+        # key only affects runtime map rendering, so the build still succeeds
+        # without it. Add a repository-level copy to make CI bundle-identical
+        # to production.
+        env:
+          NEXT_PUBLIC_MAPBOX_PUBLIC_KEY: ${{ secrets.NEXT_PUBLIC_MAPBOX_PUBLIC_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build
@@ -23,7 +27,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Build site
         run: yarn export
@@ -58,21 +62,36 @@ jobs:
         run: |
           echo "🚀 Starting parallel S3 uploads..."
 
-          # HTML, CSS, JS and other text assets (no cache header - always fresh)
-          echo "📄 [1/3] Uploading HTML, CSS, JS and text assets..."
+          # HTML and other text assets (no-cache - always revalidate)
+          echo "📄 [1/4] Uploading HTML and text assets..."
           aws s3 sync out/ s3://${{ secrets.AWS_S3_BUCKET }}/ \
             --acl public-read \
+            --cache-control no-cache \
             --follow-symlinks \
             --exclude '*.jpg' \
             --exclude '*.jpeg' \
             --exclude '*.png' \
+            --exclude '*.webp' \
+            --exclude '*.avif' \
             --exclude '*.ico' \
+            --exclude '_next/static/*' \
             --exclude 'feeds/main' \
             --exclude 'feeds/atom.xml' &
           PID1=$!
 
+          # Content-hashed bundles - the filename changes whenever the bytes do,
+          # so these can be cached permanently
+          echo "📦 [2/4] Uploading hashed build output with immutable cache..."
+          aws s3 sync out/ s3://${{ secrets.AWS_S3_BUCKET }}/ \
+            --acl public-read \
+            --cache-control 'public, max-age=31536000, immutable' \
+            --follow-symlinks \
+            --exclude '*' \
+            --include '_next/static/*' &
+          PID4=$!
+
           # Images with long cache (7 days) - these rarely change
-          echo "🖼️  [2/3] Uploading images with 7-day cache..."
+          echo "🖼️  [3/4] Uploading images with 7-day cache..."
           aws s3 sync out/ s3://${{ secrets.AWS_S3_BUCKET }}/ \
             --acl public-read \
             --cache-control max-age=604800 \
@@ -81,11 +100,13 @@ jobs:
             --include '*.jpg' \
             --include '*.jpeg' \
             --include '*.png' \
+            --include '*.webp' \
+            --include '*.avif' \
             --include '*.ico' &
           PID2=$!
 
           # RSS/Atom feeds with proper content-type for feed readers
-          echo "📡 [3/3] Uploading RSS/Atom feeds..."
+          echo "📡 [4/4] Uploading RSS/Atom feeds..."
           aws s3 sync out/ s3://${{ secrets.AWS_S3_BUCKET }}/ \
             --acl public-read \
             --follow-symlinks \
@@ -97,9 +118,10 @@ jobs:
 
           # Wait for all uploads to complete
           echo "⏳ Waiting for all uploads to complete..."
-          wait $PID1 && echo "✅ [1/3] Text assets uploaded" || { echo "❌ [1/3] Text assets failed"; exit 1; }
-          wait $PID2 && echo "✅ [2/3] Images uploaded" || { echo "❌ [2/3] Images failed"; exit 1; }
-          wait $PID3 && echo "✅ [3/3] Feeds uploaded" || { echo "❌ [3/3] Feeds failed"; exit 1; }
+          wait $PID1 && echo "✅ [1/4] Text assets uploaded" || { echo "❌ [1/4] Text assets failed"; exit 1; }
+          wait $PID4 && echo "✅ [2/4] Hashed build output uploaded" || { echo "❌ [2/4] Hashed build output failed"; exit 1; }
+          wait $PID2 && echo "✅ [3/4] Images uploaded" || { echo "❌ [3/4] Images failed"; exit 1; }
+          wait $PID3 && echo "✅ [4/4] Feeds uploaded" || { echo "❌ [4/4] Feeds failed"; exit 1; }
           echo "🎉 All S3 uploads completed successfully!"
 
   invalidate-cdn:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,6 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
 import js from "@eslint/js";
+import reactHooks from "eslint-plugin-react-hooks";
 import tseslint from "typescript-eslint";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 
 export default tseslint.config(
   js.configs.recommended,
@@ -25,6 +21,16 @@ export default tseslint.config(
       "**/*.mjs",
       "**/*.cjs"
     ],
+  },
+  {
+    files: ["app/**/*.{ts,tsx}", "components/**/*.{ts,tsx}"],
+    plugins: {
+      "react-hooks": reactHooks
+    },
+    rules: {
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn"
+    }
   },
   {
     rules: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
+    "typecheck": "tsc --noEmit",
     "export": "BLOG_EXPORT=1 next build --turbopack",
     "optimize-images": "scripts/optimize-images.sh",
     "ride:exec": "node --import @swc-node/register/esm-register",
@@ -44,6 +45,7 @@
     "decimal.js": "^10.6.0",
     "dotenv-flow": "^4.1.0",
     "eslint": "^10.8.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "feed": "^6.0.0",
     "kd-tree-javascript": "^1.0.3",
     "lodash": "^4.18.1",

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,8 @@ My personal website and blog. 👉 https://www.llun.me
 - Markdown-based blog posts with syntax highlighting
 - Interactive maps for cycling activities using Mapbox
 - Strava activity integration for tracking rides
-- RSS/Atom feed support
+- Photo galleries backed by iCloud shared albums
+- RSS, Atom and JSON feed support
 - Responsive design with Tailwind CSS
 - Optimized images and assets for fast loading
 
@@ -17,7 +18,7 @@ My personal website and blog. 👉 https://www.llun.me
 
 - [Next.js 16](https://nextjs.org/) with App Router
 - [React 19](https://react.dev/) for UI components
-- [TypeScript 5.9](https://www.typescriptlang.org/) for type safety
+- [TypeScript 6](https://www.typescriptlang.org/) for type safety
 - [Tailwind CSS 4](https://tailwindcss.com/) for styling
 - [next-themes](https://github.com/pacocoursey/next-themes) for dark mode support
 - [Lucide React](https://lucide.dev/icons/) for icons
@@ -29,19 +30,25 @@ My personal website and blog. 👉 https://www.llun.me
 ### Prerequisites
 
 - Node.js 24 or later
-- Yarn 4.12.0 (managed via Corepack)
+- Yarn 4.17.0 (managed via Corepack)
+- ImageMagick 7 (the `magick` command) for `yarn optimize-images`
 
 ### Installation
 
 1. Install all dependencies with `yarn install`
 2. Add `.env.local` with these environment variables:
-   - `NEXT_PUBLIC_DOMAIN` - Domain name for localhost, default: `http://127.0.0.1:3000`. Used for links in the page so local links work properly. Set to `https://llun.me` in GitHub Actions.
-   - `STRAVA_TOKEN` - Strava access token with access to `read_all` and `activity:read_all` scopes for fetching Strava activities and details.
+   - `NEXT_PUBLIC_MAPBOX_PUBLIC_KEY` - Mapbox public token for interactive maps. Read by `libs/config.ts`; required for any page that renders a map.
+   - `NEXT_PUBLIC_DOMAIN` - Base URL used for links, feeds and metadata. Optional; when unset the code falls back to `https://www.llun.me` (`libs/blog.ts`). The deploy workflow does not set it, so production builds use that fallback. Set it locally only when links need to point somewhere else.
+   - `STRAVA_TOKEN` - Strava access token with `read_all` and `activity:read_all` scopes, used to fetch activities and streams.
+   - `STRAVA_CLIENT_ID` - Strava API application client ID, used to refresh the access token.
+   - `STRAVA_CLIENT_SECRET` - Strava API application client secret, used to refresh the access token.
+   - `STRAVA_REFRESH_TOKEN` - Strava refresh token. Strava rotates this on every refresh, so it has to be persisted between runs.
    - `AWS_ACCOUNT_ID` - AWS Account ID
    - `AWS_ACCESS_KEY_ID` - AWS Key for running infrastructure code
    - `AWS_CLOUDFRONT_DISTRIBUTION` - CloudFront distribution ID
    - `AWS_SECRET_ACCESS_KEY` - AWS Secret for running infrastructure code
-   - `MAPBOX_PUBLIC_KEY` - Mapbox API key for interactive maps
+
+When `STRAVA_TOKEN` is rejected, `scripts/strava.ts` refreshes it with the client ID, client secret and refresh token, then **rewrites `.env.local` in place** - it replaces the existing `STRAVA_TOKEN` and `STRAVA_REFRESH_TOKEN` lines, or appends them if they are missing, and creates the file with mode `0600` when it does not exist yet. The rest of the file, including comments on other lines, is preserved. Anything on the same line as those two keys is not, and a key written with a prefix such as `export ` or with leading whitespace is not recognised and gets appended a second time.
 
 ## Development
 
@@ -58,6 +65,9 @@ yarn export
 # Run linting
 yarn lint
 
+# Type check without emitting
+yarn typecheck
+
 # Process Strava activities and generate ride statistics
 yarn ride
 
@@ -65,19 +75,31 @@ yarn ride
 yarn optimize-images
 ```
 
+`NEXT_PUBLIC_MAPBOX_PUBLIC_KEY` must be present in `.env.local` before starting the dev server. Without it the Mapbox token resolves to an empty string and every page with a map - the ride pages and the AirTag journey - throws `An API access token is required to use Mapbox GL` at runtime and fails to render. Next.js inlines `NEXT_PUBLIC_*` values at build time, so restart `yarn dev` after adding it.
+
 ## Scripts
 
-The `scripts/` directory contains utility scripts for data processing:
+The `scripts/` directory contains utility scripts for data processing.
+
+`yarn ride` runs this pipeline in order:
 
 - `load-netherlands-activities.ts` - Fetches Strava activities from Netherlands
 - `load-slovenia-activities.ts` - Fetches Strava activities from Slovenia
-- `load-singapore-activities.ts` - Fetches Strava activities from Singapore
 - `simplify-gps.ts` - Simplifies GPS coordinates for better performance
 - `generate-rides-stats.ts` - Generates statistics from ride data
-- `optimize-images.sh` - Optimizes images for web delivery
-- `strava.ts` - Strava API integration utilities
+
+Run on demand, outside the pipeline:
+
+- `load-singapore-activities.ts` - Fetches Strava activities from Singapore. Deliberately left out of `yarn ride`; the Singapore rides are historical and only need re-fetching by hand.
+- `merge-gps.ts` - Experimental kd-tree matching of overlapping Netherlands ride tracks. Not wired into any script, writes scratch GeoJSON into `scripts/`, and is run directly when exploring route overlaps.
+- `optimize-images.sh` - Optimizes images for web delivery, via `yarn optimize-images`. Requires ImageMagick 7.
+
+Shared modules:
+
+- `strava.ts` - Strava API integration utilities, including token refresh
 - `ride-utils.ts` - Utility functions for processing ride data
 - `country-utils.ts` - Country-specific utility functions
+- `constTypes.ts` - Shared types and data paths used by the ride scripts
 
 ## Code Style
 
@@ -102,7 +124,7 @@ This project uses ESLint and Prettier for code formatting and quality.
 - `app/` - Next.js 16 App Router pages and layouts
   - `(header)/` - Pages with header layout
   - `(noheader)/` - Pages without header layout
-  - `api/` - API routes
+  - `api/` - API routes. `api/apple/` proxies iCloud shared album asset URLs. It is not part of the static export - `yarn export` sets `output: 'export'`, which drops route handlers - and is served by the Vercel deployment instead, so it is live code even though it never appears in `out/`.
 - `components/` - React components
 - `contents/` - Blog posts and content in markdown format
 - `infrastructure/` - AWS infrastructure deployment scripts
@@ -115,29 +137,42 @@ This project uses ESLint and Prettier for code formatting and quality.
 
 ## Infrastructure
 
-The site is deployed using a multi-stage GitHub Actions workflow:
+The project has two deployment targets and both are live.
 
-1. **Build**: Exports static site using Next.js
-2. **Upload to S3**: Parallel uploads of different asset types
-   - HTML/CSS/JS with no caching (always fresh)
-   - Images with 7-day cache
-   - RSS/Atom feeds with proper content-type headers
+**1. Static site on S3 + CloudFront** - the public website at https://www.llun.me. Deployed by `.github/workflows/deploy.yml` on every push to master, in three stages:
+
+1. **Build**: Exports static site using Next.js (`yarn export`, which sets `BLOG_EXPORT=1` and turns on `output: 'export'`)
+2. **Upload to S3**: Four parallel syncs, one per caching policy
+   - HTML and other text assets with `no-cache`, so CloudFront revalidates them
+   - Content-hashed build output under `_next/static/` with a one-year immutable cache - the filename changes whenever the bytes do
+   - Images (jpg, jpeg, png, webp, avif, ico) with a 7-day cache
+   - Atom feeds (`feeds/main`, `feeds/atom.xml`) with an `application/atom+xml` content-type
 3. **CDN Invalidation**: CloudFront cache invalidation for immediate updates
+
+**2. Vercel** - builds the same repository without `BLOG_EXPORT`, so `output: 'export'` stays off and `app/api/apple` is deployed as a real route handler. This is the only thing Vercel serves that the static site cannot do itself: the exported pages call it cross-origin at `https://next.llun.dev/api/apple/` (`libs/apple/media.ts`) to resolve iCloud shared album asset URLs, and the route restricts callers with the `ALLOW_ORIGINS` and `ALLOW_TOKEN_IDS` lists in `libs/config.ts`. In development the same code calls the local `/api/apple/` route instead. There is no `vercel.json` in the repository, so the Vercel side is configured in its dashboard rather than here.
 
 Architecture:
 - S3 buckets for storing all blog contents and images
 - GitHub stores original content
 - GitHub Actions builds and deploys on every push to master
 - CloudFront in front of S3 buckets for global CDN
+- Vercel hosting the API route the static site depends on
 - Node.js 24 used in CI/CD pipeline
+
+### Continuous Integration
+
+`.github/workflows/ci.yml` runs on pull requests (and can be dispatched manually) and checks the branch with `yarn lint`, `yarn typecheck` and `yarn export` - the same static export the deploy workflow builds. Run the same three commands locally before pushing.
 
 ### Required GitHub Secrets
 
 For the deployment workflow to work, configure these secrets in your repository:
+- `NEXT_PUBLIC_MAPBOX_PUBLIC_KEY` - Mapbox public token, inlined into the site during the build step
 - `AWS_ACCESS_KEY_ID` - AWS access key for deployment
 - `AWS_SECRET_ACCESS_KEY` - AWS secret key for deployment
 - `AWS_S3_BUCKET` - S3 bucket name for hosting
 - `AWS_DISTRIBUTION_ID` - CloudFront distribution ID
+
+The build job runs in the `production` environment, so `NEXT_PUBLIC_MAPBOX_PUBLIC_KEY` has to be reachable from that environment. The upload and invalidation jobs declare no environment and read the `AWS_*` secrets at repository level.
 
 ## Notes
 

--- a/scripts/optimize-images.sh
+++ b/scripts/optimize-images.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
 
-magick mogrify -format webp -quality 82 public/gallery/*.jpg
-magick mogrify -format avif -quality 50 public/gallery/*.jpg
+set -euo pipefail
+
+gallery_dir=public/gallery
+
+if ! command -v magick >/dev/null 2>&1; then
+  echo "magick not found. Install ImageMagick 7 (brew install imagemagick) and try again." >&2
+  exit 1
+fi
+
+shopt -s nullglob
+images=("$gallery_dir"/*.jpg)
+shopt -u nullglob
+
+if [ ${#images[@]} -eq 0 ]; then
+  echo "No jpg files in $gallery_dir, nothing to optimize." >&2
+  exit 0
+fi
+
+magick mogrify -format webp -quality 82 "${images[@]}"
+magick mogrify -format avif -quality 50 "${images[@]}"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,12 +37,17 @@
     }
   },
   "include": [
-    "infrastructure/**/*.js",
+    "next-env.d.ts",
     "modules.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "infrastructure/**/*.js",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "out",
+    ".next"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,7 +287,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.21.3":
+"@babel/core@npm:^7.21.3, @babel/core@npm:^7.24.4":
   version: 7.29.7
   resolution: "@babel/core@npm:7.29.7"
   dependencies:
@@ -521,6 +521,17 @@ __metadata:
     "@babel/template": "npm:^7.29.7"
     "@babel/types": "npm:^7.29.7"
   checksum: 10c0/218e8d10953647c9f44775f5a022b227a182674853b5ea8631889deb7e1a3e4bc870388aaecf59bb8bd92a87f9a96220ed3f70a35bffec6bcf9169ecb67891ac
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.24.4":
+  version: 7.29.8
+  resolution: "@babel/parser@npm:7.29.8"
+  dependencies:
+    "@babel/types": "npm:^7.29.8"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/acc890c5e6a6dd40863a47b50bac111d7185ee6fbbe163ebe11d5214854ca2adb901462ad4d718a65090ef84bd2230e9e8ab45a2e0caccc685f1f57ab0bb1e28
   languageName: node
   linkType: hard
 
@@ -1484,6 +1495,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.29.7"
     "@babel/helper-validator-identifier": "npm:^7.29.7"
   checksum: 10c0/b6623994c69717fa27294f5fa46d59140338e2d86c6c1c13085c84ef7d53086ee357fbf4fe9abe3dd3da75734dc77c4c0df2f90fb29e667558bb3b3fb705e88f
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/types@npm:7.29.8"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10c0/be7c279f0abf2a086c633e21b49c7ca80275d05283cc5a268b67a708c9914bd0c944f1422b3eb3cb37682a2af5d560abf520ccf9b01b53ecbfe6b71fbc3fdde6
   languageName: node
   linkType: hard
 
@@ -3815,6 +3836,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-react-hooks@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "eslint-plugin-react-hooks@npm:7.1.1"
+  dependencies:
+    "@babel/core": "npm:^7.24.4"
+    "@babel/parser": "npm:^7.24.4"
+    hermes-parser: "npm:^0.25.1"
+    zod: "npm:^3.25.0 || ^4.0.0"
+    zod-validation-error: "npm:^3.5.0 || ^4.0.0"
+  peerDependencies:
+    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+  checksum: 10c0/cee8454915d71ac5d70a0d8f4f260e76eaf45fcd4162747dd4282b792ee5616d187351dabe6cdcff9040c79d0cec625635c4fd0777276be119efa88ebe058525
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:^9.1.2":
   version: 9.1.2
   resolution: "eslint-scope@npm:9.1.2"
@@ -4171,6 +4207,22 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
+  languageName: node
+  linkType: hard
+
+"hermes-estree@npm:0.25.1":
+  version: 0.25.1
+  resolution: "hermes-estree@npm:0.25.1"
+  checksum: 10c0/48be3b2fa37a0cbc77a112a89096fa212f25d06de92781b163d67853d210a8a5c3784fac23d7d48335058f7ed283115c87b4332c2a2abaaccc76d0ead1a282ac
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:^0.25.1":
+  version: 0.25.1
+  resolution: "hermes-parser@npm:0.25.1"
+  dependencies:
+    hermes-estree: "npm:0.25.1"
+  checksum: 10c0/3abaa4c6f1bcc25273f267297a89a4904963ea29af19b8e4f6eabe04f1c2c7e9abd7bfc4730ddb1d58f2ea04b6fee74053d8bddb5656ec6ebf6c79cc8d14202c
   languageName: node
   linkType: hard
 
@@ -4594,6 +4646,7 @@ __metadata:
     decimal.js: "npm:^10.6.0"
     dotenv-flow: "npm:^4.1.0"
     eslint: "npm:^10.8.0"
+    eslint-plugin-react-hooks: "npm:^7.1.1"
     feed: "npm:^6.0.0"
     kd-tree-javascript: "npm:^1.0.3"
     lodash: "npm:^4.18.1"
@@ -5749,5 +5802,21 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"zod-validation-error@npm:^3.5.0 || ^4.0.0":
+  version: 4.0.2
+  resolution: "zod-validation-error@npm:4.0.2"
+  peerDependencies:
+    zod: ^3.25.0 || ^4.0.0
+  checksum: 10c0/0ccfec48c46de1be440b719cd02044d4abb89ed0e14c13e637cd55bf29102f67ccdba373f25def0fc7130e5f15025be4d557a7edcc95d5a3811599aade689e1b
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.0 || ^4.0.0":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
   languageName: node
   linkType: hard


### PR DESCRIPTION
Third of four PRs from the codebase review. Tooling and CI only — no runtime code changes.

## Type checking now actually covers the code

`tsconfig.json`'s `include` listed only `infrastructure/**/*.js`, `modules.d.ts` and generated `.next` types. So `app/`, `components/` and `libs/` were checked only transitively through `.next/types` (i.e. only *after* a build had generated them), and `scripts/` was never checked at all — `@swc-node/register` transpiles without type checking.

Widening it to the standard globs surfaced **zero errors across 75 files**. The code was already clean; nothing was looking at it. Added `yarn typecheck` so it can be run on its own.

## A PR gate that didn't exist

Nothing ran lint, typecheck or a build on pull requests — the only signal was the production deploy *after* merge. `.github/workflows/ci.yml` now runs all three on every PR, reusing deploy.yml's Node 24 + corepack ordering and action majors.

Note: `NEXT_PUBLIC_MAPBOX_PUBLIC_KEY` is scoped to the `production` environment, which CI deliberately does not join, so it is empty on every PR. The build succeeds regardless (the key only affects runtime map rendering). If you want CI bundle-identical to production, add a repository-level copy of that secret — it's a public `pk.` token, so the exposure is the same as shipping it in the JS bundle.

## Linting now catches the class of bug from PR #30

Added `eslint-plugin-react-hooks`: `rules-of-hooks` as an error, `exhaustive-deps` as a warning, and `lint` now runs with `--max-warnings 0` so warnings actually gate rather than scroll past.

I verified the rule fires rather than assuming it — a probe component with a dependency-less `useEffect` calling `setState` produces exactly the expected warning. That's the defect behind three of the bugs fixed in #30 (RideMap, CopierIcon, Modal), so this closes the door on regressions. The repo is warning-free today, so the stricter gate costs nothing now.

## deploy.yml

- **Concurrency group** so overlapping production deploys serialize, with `cancel-in-progress: false` — an in-flight S3 sync must not be killed halfway.
- **`.webp` and `.avif` were missing from the image pass.** `public/gallery/` is full of them and they're the formats browsers actually receive, yet they fell through to the first sync and uploaded with no `Cache-Control` at all.
- **HTML now uploads with `no-cache`**, which the readme already claimed but the workflow never did (CloudFront's `DefaultTTL` is 86400, so correctness rested entirely on the invalidation).
- **Hashed bundles got their own pass.** This one matters: adding `no-cache` to the first sync would have applied it to `_next/static/**` too, and those files are content-hashed — immutable by filename. With `MinTTL: 1` that means CloudFront revalidating every chunk on essentially every page view. They now upload separately with `max-age=31536000, immutable`, which is a net improvement over the previous unlabelled 1-day TTL.
- `yarn install --immutable`, so lockfile drift fails CI instead of silently resolving.

## Smaller things

`optimize-images.sh` gained `set -euo pipefail`, a check that ImageMagick's `magick` command exists, and an empty-glob guard — same formats and quality as before.

The **readme was substantially wrong**: Yarn 4.12 → 4.17, TypeScript 5.9 → 6, `MAPBOX_PUBLIC_KEY` → its real name `NEXT_PUBLIC_MAPBOX_PUBLIC_KEY`, and a `NEXT_PUBLIC_DOMAIN` description claiming both a localhost default and a value set in Actions, neither of which is true. Now also documents the three Strava credentials that were missing (and that `strava.ts` rewrites `.env.local`), the Mapbox secret absent from the secrets list, ImageMagick as a prerequisite, and the trap where a missing Mapbox key leaves ride pages throwing at runtime.

Most importantly it now documents **both deployments** — the S3 static export *and* the Vercel one serving `app/api/apple` — so that route isn't mistaken for dead code under `output: 'export'`.

## Verification

`yarn lint` (at `--max-warnings 0`), `yarn typecheck` (across all 75 files) and both build targets pass, producing the same 682 pages. `deploy.yml`'s S3 block was extracted and checked with `bash -n`: syntax valid, all four background syncs have matching `wait` calls, and every line continuation and trailing `&` is intact. Every factual claim in the readme was re-checked against the actual files.

Still open and unrelated to this PR: the two published posts embedding the old Mapbox token, whose maps render blank on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)