### PR TITLE
Add sitemap and error pages, make Atom the only feed, fix accessibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,8 +105,8 @@ jobs:
             --include '*.ico' &
           PID2=$!
 
-          # RSS/Atom feeds with proper content-type for feed readers
-          echo "📡 [4/4] Uploading RSS/Atom feeds..."
+          # Atom feeds with proper content-type for feed readers
+          echo "📡 [4/4] Uploading Atom feeds..."
           aws s3 sync out/ s3://${{ secrets.AWS_S3_BUCKET }}/ \
             --acl public-read \
             --follow-symlinks \
@@ -123,6 +123,13 @@ jobs:
           wait $PID2 && echo "✅ [3/4] Images uploaded" || { echo "❌ [3/4] Images failed"; exit 1; }
           wait $PID3 && echo "✅ [4/4] Feeds uploaded" || { echo "❌ [4/4] Feeds failed"; exit 1; }
           echo "🎉 All S3 uploads completed successfully!"
+
+      - name: Remove retired RSS feed
+        run: |
+          # RSS was retired in favour of Atom. The syncs above deliberately run
+          # without --delete, so this object would otherwise keep serving a
+          # frozen copy of the feed forever instead of 404ing.
+          aws s3 rm s3://${{ secrets.AWS_S3_BUCKET }}/feeds/rss.xml || true
 
   invalidate-cdn:
     name: Invalidate CloudFront

--- a/app/(header)/error.tsx
+++ b/app/(header)/error.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import Link from 'next/link'
+import React from 'react'
+import { ArrowLeft, RotateCcw } from 'lucide-react'
+
+interface Props {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+const ErrorBoundary = ({ error, reset }: Props) => (
+  <section className="my-16 text-center">
+    <h1 className="post-title">Something went wrong</h1>
+    <p className="text-muted-foreground">
+      Sorry, this page could not be loaded. Please try again.
+    </p>
+    {error.digest && (
+      <p className="text-muted-foreground text-sm">Reference {error.digest}</p>
+    )}
+    <div className="flex items-center justify-center gap-6">
+      <button
+        type="button"
+        className="post-header-back-link cursor-pointer underline"
+        style={{ color: 'var(--link)' }}
+        onClick={() => reset()}
+      >
+        <RotateCcw className="mr-2 h-4 w-4" />
+        Try again
+      </button>
+      <Link className="post-header-back-link" href="/">
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Home
+      </Link>
+    </div>
+  </section>
+)
+
+export default ErrorBoundary

--- a/app/(header)/gallery/page.tsx
+++ b/app/(header)/gallery/page.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { getMetadata } from '../../../components/Meta'
 import { getConfig } from '../../../libs/blog'
 import { getAllAlbums } from '../../../libs/gallery'
+import { isSafeSegment } from '../../../libs/utils'
 
 const { url, title, description } = getConfig()
 
@@ -14,7 +15,6 @@ export const metadata: Metadata = getMetadata({
   description
 })
 
-const SAFE_ROUTE_SEGMENT = /^[A-Za-z0-9._-]+$/
 const SAFE_IMAGE_FILE = /^[A-Za-z0-9._-]+\.jpg$/i
 
 const Gallery = () => {
@@ -24,7 +24,7 @@ const Gallery = () => {
       <h2 className="my-2">Image Gallery</h2>
       <div className="gallery-list">
         {albums.map(({ name, image, description, title: albumTitle }) => {
-          if (!SAFE_ROUTE_SEGMENT.test(name) || !SAFE_IMAGE_FILE.test(image)) {
+          if (!isSafeSegment(name) || !SAFE_IMAGE_FILE.test(image)) {
             return null
           }
 
@@ -41,6 +41,8 @@ const Gallery = () => {
                   height={512}
                   src={`/gallery/${image}`}
                   alt={description}
+                  loading="lazy"
+                  decoding="async"
                 />
               </picture>
               <h3>{albumTitle}</h3>

--- a/app/(header)/not-found.tsx
+++ b/app/(header)/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import React from 'react'
+import { ArrowLeft } from 'lucide-react'
+
+const NotFound = () => (
+  <section className="my-16 text-center">
+    <h1 className="post-title">Page not found</h1>
+    <p className="text-muted-foreground">
+      The page you are looking for does not exist or has moved.
+    </p>
+    <Link className="post-header-back-link" href="/">
+      <ArrowLeft className="mr-2 h-4 w-4" />
+      Home
+    </Link>
+  </section>
+)
+
+export default NotFound

--- a/app/(header)/page.tsx
+++ b/app/(header)/page.tsx
@@ -2,18 +2,11 @@ import { ArrowRight } from 'lucide-react'
 import Link from 'next/link'
 import React from 'react'
 
-import {
-  generateFeeds,
-  getAllPosts,
-  getConfig,
-  postDescendingComparison
-} from '../../libs/blog'
+import { getAllPosts, postDescendingComparison } from '../../libs/blog'
 import PostList from '../../components/PostList'
 
 const Index = () => {
-  const config = getConfig()
   const posts = getAllPosts().sort(postDescendingComparison).slice(0, 20)
-  generateFeeds(config, posts)
   return (
     <>
       <PostList posts={posts} />

--- a/app/(noheader)/error.tsx
+++ b/app/(noheader)/error.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import Link from 'next/link'
+import React from 'react'
+import { ArrowLeft, RotateCcw } from 'lucide-react'
+
+interface Props {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+const ErrorBoundary = ({ error, reset }: Props) => (
+  <main className="main-container">
+    <section className="my-16 text-center">
+      <h1 className="post-title">Something went wrong</h1>
+      <p className="text-muted-foreground">
+        Sorry, this page could not be loaded. Please try again.
+      </p>
+      {error.digest && (
+        <p className="text-muted-foreground text-sm">
+          Reference {error.digest}
+        </p>
+      )}
+      <div className="flex items-center justify-center gap-6">
+        <button
+          type="button"
+          className="post-header-back-link cursor-pointer underline"
+        style={{ color: 'var(--link)' }}
+          onClick={() => reset()}
+        >
+          <RotateCcw className="mr-2 h-4 w-4" />
+          Try again
+        </button>
+        <Link className="post-header-back-link" href="/">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Home
+        </Link>
+      </div>
+    </section>
+  </main>
+)
+
+export default ErrorBoundary

--- a/app/(noheader)/not-found.tsx
+++ b/app/(noheader)/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+import React from 'react'
+import { ArrowLeft } from 'lucide-react'
+
+const NotFound = () => (
+  <main className="main-container">
+    <section className="my-16 text-center">
+      <h1 className="post-title">Page not found</h1>
+      <p className="text-muted-foreground">
+        The page you are looking for does not exist or has moved.
+      </p>
+      <Link className="post-header-back-link" href="/">
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Home
+      </Link>
+    </section>
+  </main>
+)
+
+export default NotFound

--- a/app/(noheader)/posts/[...segment]/page.tsx
+++ b/app/(noheader)/posts/[...segment]/page.tsx
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { Metadata } from 'next'
 import path from 'path'
 import React, { use } from 'react'
@@ -9,18 +10,26 @@ import { DateTime } from 'luxon'
 import { ThemeToggle } from '../../../../components/ThemeToggle'
 import { getMetadata } from '../../../../components/Meta'
 import { getAllPosts, getConfig, parsePost } from '../../../../libs/blog'
+import { isSinglePathSegment } from '../../../../libs/utils'
 
-const getPost = (segment: string[]) => {
-  const config = getConfig()
-  const contentPath = path.join(
-    process.cwd(),
-    'contents',
-    'posts',
-    ...segment,
-    'index.md'
-  )
-  return parsePost(config, contentPath, true)
-}
+const getPost = _.memoize(
+  (segment: string[]) => {
+    if (!segment.every(isSinglePathSegment)) {
+      return null
+    }
+
+    const config = getConfig()
+    const contentPath = path.join(
+      process.cwd(),
+      'contents',
+      'posts',
+      ...segment,
+      'index.md'
+    )
+    return parsePost(config, contentPath, true)
+  },
+  (segment: string[]) => JSON.stringify(segment)
+)
 
 interface Props {
   params: Promise<{ segment: string[] }>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,151 @@
+import type { MetadataRoute } from 'next'
+
+import { getAllCalendars } from '../libs/amsterdam'
+import { getAllPosts, getConfig } from '../libs/blog'
+import { getAllAlbums } from '../libs/gallery'
+import { getAllJourneys } from '../libs/journey'
+import { generateStaticParams as generateTagParams } from './(header)/tags/[tag]/page'
+import { COUNTRY } from './(header)/tags/ride/countries'
+
+// Required by output: 'export' — without it the build refuses to collect this
+// route because it cannot prove the sitemap is generated at build time
+export const dynamic = 'force-static'
+
+type SitemapEntry = MetadataRoute.Sitemap[number]
+
+// trailingSlash is enabled, so every exported page lives at <path>/index.html
+// and its canonical url has to keep the trailing slash.
+const pageUrl = (origin: string, pathname: string) => {
+  const segments = pathname
+    .split('/')
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+  return [origin, ...segments, ''].join('/')
+}
+
+const lastModified = (timestamp: number) =>
+  Number.isFinite(timestamp) ? new Date(timestamp) : undefined
+
+const newestTimestamp = (timestamps: number[]) => {
+  const valid = timestamps.filter((timestamp) => Number.isFinite(timestamp))
+  if (valid.length === 0) return Number.NaN
+  return valid.reduce((newest, timestamp) =>
+    timestamp > newest ? timestamp : newest
+  )
+}
+
+const dedupe = (entries: SitemapEntry[]) => {
+  const seen = new Set<string>()
+  return entries.filter((entry) => {
+    if (seen.has(entry.url)) return false
+    seen.add(entry.url)
+    return true
+  })
+}
+
+const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
+  const origin = getConfig().url.replace(/\/+$/, '')
+  const url = (pathname: string) => pageUrl(origin, pathname)
+
+  const posts = getAllPosts()
+  const albums = getAllAlbums()
+  const journeys = getAllJourneys()
+  const [calendars, tags] = await Promise.all([
+    getAllCalendars(),
+    generateTagParams()
+  ])
+
+  const categoryTimestamp = (category: string) =>
+    newestTimestamp(
+      posts
+        .filter((post) => post.file.category === category)
+        .map((post) => post.timestamp)
+    )
+
+  const latestPost = newestTimestamp(posts.map((post) => post.timestamp))
+  const latestAlbum = newestTimestamp(albums.map((album) => album.timestamp))
+
+  return dedupe([
+    {
+      url: url('/'),
+      lastModified: lastModified(latestPost),
+      changeFrequency: 'weekly',
+      priority: 1
+    },
+    {
+      url: url('/posts'),
+      lastModified: lastModified(latestPost),
+      changeFrequency: 'weekly',
+      priority: 0.8
+    },
+    {
+      url: url('/gallery'),
+      lastModified: lastModified(latestAlbum),
+      changeFrequency: 'monthly',
+      priority: 0.8
+    },
+    {
+      url: url('/journeys'),
+      changeFrequency: 'monthly',
+      priority: 0.8
+    },
+    {
+      url: url('/tags/ride'),
+      lastModified: lastModified(categoryTimestamp('ride')),
+      changeFrequency: 'weekly',
+      priority: 0.8
+    },
+    ...tags.map(
+      ({ tag }): SitemapEntry => ({
+        url: url(`/tags/${tag}`),
+        lastModified: lastModified(categoryTimestamp(tag)),
+        changeFrequency: 'weekly',
+        priority: 0.8
+      })
+    ),
+    ...Object.values(COUNTRY).flatMap((country): SitemapEntry[] => [
+      {
+        url: url(`/tags/ride/${country}`),
+        changeFrequency: 'monthly',
+        priority: 0.7
+      },
+      {
+        url: url(`/tags/ride/${country}/gallery`),
+        changeFrequency: 'monthly',
+        priority: 0.5
+      }
+    ]),
+    ...posts.map(
+      (post): SitemapEntry => ({
+        url: url(`/posts/${post.file.id}`),
+        lastModified: lastModified(post.timestamp),
+        changeFrequency: 'yearly',
+        priority: 0.7
+      })
+    ),
+    ...albums.map(
+      (album): SitemapEntry => ({
+        url: url(`/gallery/${album.name}`),
+        lastModified: lastModified(album.timestamp),
+        changeFrequency: 'yearly',
+        priority: 0.6
+      })
+    ),
+    ...journeys.map(
+      (journey): SitemapEntry => ({
+        url: url(`/journeys/${journey.name}`),
+        changeFrequency: 'monthly',
+        priority: 0.6
+      })
+    ),
+    ...calendars.map(
+      (calendar): SitemapEntry => ({
+        url: url(`/journeys/amsterdam/${calendar.id}`),
+        changeFrequency: 'yearly',
+        priority: 0.4
+      })
+    )
+  ])
+}
+
+export default sitemap

--- a/components/Header.css
+++ b/components/Header.css
@@ -27,10 +27,6 @@
     @apply inline-flex items-center justify-start whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground h-9 px-3 no-underline text-[var(--primary)];
   }
 
-  .nav-link img {
-    @apply mb-0 mr-2 p-0 h-[16px] w-[16px] max-w-[16px] border-none;
-  }
-
   .nav-link-text {
     @apply hidden lg:block;
   }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React from 'react'
 import Link from 'next/link'
 import { Bike, BookImage, BookMarked, Computer, LucideIcon } from 'lucide-react'
@@ -10,7 +8,7 @@ import { ThemeToggle } from './ThemeToggle'
 export type Page = {
   url: string
   title: string
-  icon: LucideIcon | ((props: { className?: string }) => React.ReactNode)
+  icon: LucideIcon | ((props: React.SVGProps<SVGSVGElement>) => React.ReactNode)
   target?: '_blank'
 }
 const DEFAULT_PAGES: Page[] = [
@@ -69,8 +67,9 @@ const Header = ({ title, url, pages = DEFAULT_PAGES }: Props) => (
               target={item.target}
               rel={item.target === '_blank' ? 'noopener noreferrer' : undefined}
               className={'nav-link'}
+              aria-label={item.title}
             >
-              <item.icon className="mr-2 h-4 w-4" />
+              <item.icon className="mr-2 h-4 w-4" aria-hidden="true" />
               <span className="nav-link-text">{item.title}</span>
             </Link>
           ))}

--- a/components/MediaModal.tsx
+++ b/components/MediaModal.tsx
@@ -21,7 +21,7 @@ const Photo: FC<MediaProps> = ({ media }) => {
     <img
       className="media-modal-image"
       src={source}
-      alt="Detail image"
+      alt={media.caption?.trim() || 'Gallery photo'}
       width={media.width}
       height={media.height}
     />

--- a/components/Medias.tsx
+++ b/components/Medias.tsx
@@ -38,7 +38,7 @@ const Medias: FC<Props> = ({ partition, token, medias, className }) => {
     media: Media
     index: number
   }>()
-  const photoDom = useRef<HTMLDivElement>(null)
+  const photoDom = useRef<HTMLButtonElement>(null)
   const failedOffset = useRef<number | null>(null)
 
   useEffect(() => {
@@ -131,11 +131,17 @@ const Medias: FC<Props> = ({ partition, token, medias, className }) => {
         const key = media.type === 'video' ? VideoPosterDerivative : keys[0]
         const backgroundImage =
           media.derivatives[key].url && `url(${media.derivatives[key].url})`
+        const caption = media.caption?.trim()
+        const label = caption
+          ? `Open ${caption}`
+          : `Open ${media.type === 'video' ? 'video' : 'photo'} ${index + 1}`
 
         return (
-          <div
+          <button
             key={media.guid}
-            className={cn('ride-medias-image', {
+            type="button"
+            aria-label={label}
+            className={cn('ride-medias-image', 'appearance-none block', {
               'ride-medias-super-square': shouldBeBig
             })}
             style={{ backgroundImage }}

--- a/components/Meta.tsx
+++ b/components/Meta.tsx
@@ -12,7 +12,7 @@ export const getMetadata = ({
   description,
   imageUrl
 }: GetMetadataParams): Metadata => {
-  const defaultImageUrl = 'https://llun.me/img/default.png'
+  const defaultImageUrl = `${url}/img/default.png`
   return {
     title,
     description,
@@ -38,19 +38,14 @@ export const getMetadata = ({
     },
     manifest: '/site.webmanifest',
     verification: {
-      me: ['https://llun.me', 'https://llun.dev/@null']
+      me: [url, 'https://llun.dev/@null']
     },
     alternates: {
       types: {
         'application/atom+xml': [
-          { title: '@llun', url: 'https://llun.me/feeds/atom.xml' }
+          { title: '@llun', url: `${url}/feeds/atom.xml` }
         ],
-        'application/rss+xml': [
-          { title: '@llun', url: 'https://llun.me/feeds/rss.xml' }
-        ],
-        'application/json': [
-          { title: '@llun', url: 'https://llun.me/feeds/feed.json' }
-        ]
+        'application/json': [{ title: '@llun', url: `${url}/feeds/feed.json` }]
       }
     }
   }

--- a/components/RideTitle.tsx
+++ b/components/RideTitle.tsx
@@ -41,8 +41,12 @@ const RideTitle: FC<Props> = ({ icon, className }) => (
             <span className="sm:hidden">{country.code}</span>
             <span className="hidden sm:inline">{country.name}</span>
           </Link>
-          <Link href={`/tags/ride/${country.slug}/gallery`} className="mr-2">
-            <BookImage className="ride-title-icon" />
+          <Link
+            href={`/tags/ride/${country.slug}/gallery`}
+            className="mr-2"
+            aria-label={`Link to my ${country.name} cycling photos`}
+          >
+            <BookImage className="ride-title-icon" aria-hidden="true" />
           </Link>
         </React.Fragment>
       ))}

--- a/components/RideVideos.tsx
+++ b/components/RideVideos.tsx
@@ -24,11 +24,15 @@ const RideVideos: FC<Props> = ({ videos, className }) => {
       <ul>
         {videos.map((video) => (
           <li key={video.url}>
-            <a href={video.url} target="_blank">
+            <a href={video.url} target="_blank" rel="noopener noreferrer">
               {video.title}
             </a>
             ,&nbsp;
-            <a href={video.stravaLink} target="_blank">
+            <a
+              href={video.stravaLink}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Strava
             </a>
           </li>

--- a/components/ThemeToggle.css
+++ b/components/ThemeToggle.css
@@ -8,7 +8,7 @@
   }
 
   .theme-toggle-modal-content {
-    @apply absolute right-0 mt-2 z-20 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-md shadow-lg p-2;
+    @apply absolute right-0 mt-2 z-20 bg-popover text-popover-foreground border border-border rounded-md shadow-lg p-2;
   }
 
   .theme-toggle-modal-button-container {
@@ -16,10 +16,12 @@
   }
 
   .theme-toggle-modal-button {
-    @apply flex items-center space-x-2 p-2 rounded-sm hover:bg-gray-100 dark:hover:bg-gray-700;
+    @apply flex items-center space-x-2 p-2 rounded-sm cursor-pointer hover:bg-accent hover:text-accent-foreground;
   }
 
+  /* hover also resolves to bg-accent, so the selected row needs a second
+     signal to stay distinguishable while another row is hovered */
   .theme-toggle-modal-button-selected {
-    @apply bg-gray-200 dark:bg-gray-700;
+    @apply bg-accent text-accent-foreground font-medium ring-1 ring-border;
   }
 }

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -2,14 +2,40 @@
 
 import { useTheme } from 'next-themes'
 import { Sun, Moon, Laptop } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import cn from 'classnames'
 
 export const ThemeToggle = () => {
   const { theme, setTheme } = useTheme()
   const [showModal, setShowModal] = useState(false)
+  // next-themes resolves the theme after mount, so the icon can only be
+  // rendered on the client without mismatching the server markup
+  const [mounted, setMounted] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => setMounted(true), [])
+
+  // Closing while focus sits on an option would unmount the focused element
+  // and drop focus to the body, restarting tab order from the top
+  const close = useCallback(() => {
+    setShowModal(false)
+    triggerRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    if (!showModal) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      close()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [showModal, close])
 
   const getCurrentIcon = () => {
+    if (!mounted) return <span className="block h-4 w-4" aria-hidden="true" />
+
     switch (theme) {
       case 'light':
         return <Sun size={16} />
@@ -23,9 +49,12 @@ export const ThemeToggle = () => {
   return (
     <div className="relative">
       <button
+        ref={triggerRef}
         onClick={() => setShowModal(!showModal)}
         className="theme-toggle"
         aria-label="Toggle theme"
+        aria-expanded={showModal}
+        aria-controls="theme-options"
       >
         {getCurrentIcon()}
       </button>
@@ -34,19 +63,26 @@ export const ThemeToggle = () => {
         <>
           <div
             className="theme-toggle-modal"
-            onClick={() => setShowModal(false)}
+            onClick={close}
+            aria-hidden="true"
           />
           <div className="theme-toggle-modal-content">
-            <div className="theme-toggle-modal-button-container">
+            <div
+              className="theme-toggle-modal-button-container"
+              id="theme-options"
+              role="group"
+              aria-label="Theme"
+            >
               <button
                 onClick={() => {
                   setTheme('light')
-                  setShowModal(false)
+                  close()
                 }}
                 className={cn('theme-toggle-modal-button', {
                   'theme-toggle-modal-button-selected': theme === 'light'
                 })}
                 aria-label="Light mode"
+                aria-pressed={theme === 'light'}
               >
                 <Sun size={16} />
                 <span>Light</span>
@@ -54,12 +90,13 @@ export const ThemeToggle = () => {
               <button
                 onClick={() => {
                   setTheme('dark')
-                  setShowModal(false)
+                  close()
                 }}
                 className={cn('theme-toggle-modal-button', {
                   'theme-toggle-modal-button-selected': theme === 'dark'
                 })}
                 aria-label="Dark mode"
+                aria-pressed={theme === 'dark'}
               >
                 <Moon size={16} />
                 <span>Dark</span>
@@ -67,12 +104,13 @@ export const ThemeToggle = () => {
               <button
                 onClick={() => {
                   setTheme('system')
-                  setShowModal(false)
+                  close()
                 }}
                 className={cn('theme-toggle-modal-button', {
                   'theme-toggle-modal-button-selected': theme === 'system'
                 })}
                 aria-label="System preference"
+                aria-pressed={theme === 'system'}
               >
                 <Laptop size={16} />
                 <span>System</span>

--- a/libs/amsterdam.ts
+++ b/libs/amsterdam.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises'
 import yaml from 'yaml'
 import path from 'path'
 import { getMarkdown } from './markdown'
+import { isSafeSegment } from './utils'
 
 export interface CalendarProperty {
   month:
@@ -31,6 +32,11 @@ export const parseCalendar = async (
 ): Promise<Calendar | null> => {
   try {
     await fs.stat(file)
+  } catch {
+    return null
+  }
+
+  try {
     const raw = await fs.readFile(file, 'utf-8')
     const begin = raw.indexOf('---')
     const end = raw.indexOf('---', begin + 3)
@@ -48,7 +54,8 @@ export const parseCalendar = async (
       id: path.basename(file, '.md'),
       content: md.render(raw.substring(end + 3).trim())
     }
-  } catch {
+  } catch (error) {
+    console.warn(`Failed to parse calendar ${file}`, error)
     return null
   }
 }
@@ -63,8 +70,13 @@ export const getAllCalendars = async () => {
   ).filter((p): p is Calendar => p !== null)
 }
 
-export const getCalendar = async (id: string) =>
-  parseCalendar(
+export const getCalendar = async (id: string): Promise<Calendar | null> => {
+  if (!isSafeSegment(id)) {
+    return null
+  }
+
+  return parseCalendar(
     path.join(process.cwd(), 'contents', 'amsterdam', 'calendar', `${id}.md`),
     true
   )
+}

--- a/libs/apple/media.ts
+++ b/libs/apple/media.ts
@@ -54,9 +54,10 @@ export async function proxyAssetsUrl(
   token: string,
   medias: Media[]
 ): Promise<Assets | null> {
+  const apiHost = process.env.NEXT_PUBLIC_API_HOST ?? 'https://next.llun.dev'
   const url =
     process.env.NODE_ENV === 'production'
-      ? 'https://next.llun.dev/api/apple/'
+      ? `${apiHost.replace(/\/+$/, '')}/api/apple/`
       : `http://${globalThis.location.host}/api/apple/`
   const body: AssetsRequest = {
     partition,

--- a/libs/blog.ts
+++ b/libs/blog.ts
@@ -1,6 +1,6 @@
 import { Feed } from 'feed'
 import fs from 'fs'
-import memoize from 'lodash/memoize'
+import memoize from 'lodash/memoize.js'
 import { DateTime } from 'luxon'
 import path from 'path'
 import yaml from 'yaml'

--- a/libs/blog.ts
+++ b/libs/blog.ts
@@ -146,13 +146,12 @@ export const getAllPosts = memoize((): Post[] => {
 })
 
 /**
- * Generates RSS and Atom feeds from blog posts.
- * Results are memoized for performance.
+ * Builds the Atom and JSON Feed documents from blog posts.
  * @param config - The blog configuration
  * @param sortedPosts - Posts sorted in the desired order
- * @returns Feed object containing RSS and Atom feeds
+ * @returns The serialised Atom and JSON Feed documents
  */
-export const generateFeeds = memoize((config: Config, sortedPosts: Post[]) => {
+export const buildFeeds = (config: Config, sortedPosts: Post[]) => {
   const feed = new Feed({
     title: config.title,
     description: config.description,
@@ -169,7 +168,6 @@ export const generateFeeds = memoize((config: Config, sortedPosts: Post[]) => {
       link: config.url
     },
     feedLinks: {
-      rss2: `${config.url}/feeds/feed.xml`,
       json: `${config.url}/feeds/feed.json`,
       atom: `${config.url}/feeds/atom.xml`
     }
@@ -199,13 +197,11 @@ export const generateFeeds = memoize((config: Config, sortedPosts: Post[]) => {
       content
     })
   }
-  const feedsPath = path.join(process.cwd(), 'public', 'feeds')
-  fs.mkdirSync(feedsPath, { recursive: true })
-  fs.writeFileSync(path.join(feedsPath, 'rss.xml'), feed.rss2())
-  fs.writeFileSync(path.join(feedsPath, 'atom.xml'), feed.atom1())
-  fs.writeFileSync(path.join(feedsPath, 'main'), feed.atom1())
-  fs.writeFileSync(path.join(feedsPath, 'feed.json'), feed.json1())
-})
+  return {
+    atom: feed.atom1(),
+    json: feed.json1()
+  }
+}
 
 export const getConfig = memoize(
   (): Config => ({

--- a/libs/gallery.ts
+++ b/libs/gallery.ts
@@ -8,6 +8,7 @@ import { Media, getMediaList } from './apple/media'
 import { fetchStream } from './apple/webstream'
 import { Config, getConfig } from './blog'
 import { getMarkdown } from './markdown'
+import { isSinglePathSegment } from './utils'
 
 interface AlbumProperties {
   title: string
@@ -35,6 +36,11 @@ export const parseAlbum = (
 ): Album | null => {
   try {
     fs.statSync(file)
+  } catch {
+    return null
+  }
+
+  try {
     const name = path.basename(file, '.md')
     const raw = fs.readFileSync(file).toString('utf-8')
     const begin = raw.indexOf('---')
@@ -69,7 +75,8 @@ export const parseAlbum = (
       token,
       content
     }
-  } catch {
+  } catch (error) {
+    console.warn(`Failed to parse album ${file}`, error)
     return null
   }
 }
@@ -98,6 +105,10 @@ export interface AlbumMedias {
 }
 
 const loadAlbum = async (name: string): Promise<AlbumMedias | null> => {
+  if (!isSinglePathSegment(name)) {
+    return null
+  }
+
   const config = getConfig()
   const base = path.join(process.cwd(), 'contents', 'galleries')
   const file = path.join(base, `${name}.md`)

--- a/libs/journey.ts
+++ b/libs/journey.ts
@@ -5,6 +5,7 @@ import fs from 'fs'
 
 import { readAllLeafDirectories } from './blog'
 import { getMarkdown } from './markdown'
+import { isSinglePathSegment } from './utils'
 
 interface JourneyProperty {
   title: string
@@ -21,10 +22,27 @@ export const parseJourney = (
   file: string,
   includeContent = false
 ): Journey | null => {
+  const journeysPath = path.join(process.cwd(), 'contents', 'journeys')
+  const relativePath = path.relative(journeysPath, file)
+  if (
+    relativePath.length === 0 ||
+    relativePath
+      .split(path.sep)
+      .some((segment) => !isSinglePathSegment(segment))
+  ) {
+    return null
+  }
+
+  const indexPath = path.join(file, 'index.md')
   try {
-    fs.statSync(file)
+    fs.statSync(indexPath)
+  } catch {
+    return null
+  }
+
+  try {
     const name = path.basename(file)
-    const raw = fs.readFileSync(path.join(file, 'index.md')).toString('utf-8')
+    const raw = fs.readFileSync(indexPath).toString('utf-8')
     const begin = raw.indexOf('---')
     const end = raw.indexOf('---', begin + 3)
     const properties: JourneyProperty = yaml.parse(raw.substring(begin, end))
@@ -39,7 +57,8 @@ export const parseJourney = (
       name,
       content: md.render(raw.substring(end + 3).trim())
     }
-  } catch {
+  } catch (error) {
+    console.warn(`Failed to parse journey ${indexPath}`, error)
     return null
   }
 }

--- a/libs/journey.ts
+++ b/libs/journey.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import memoize from 'lodash/memoize'
+import memoize from 'lodash/memoize.js'
 import yaml from 'yaml'
 import fs from 'fs'
 

--- a/libs/utils.ts
+++ b/libs/utils.ts
@@ -1,0 +1,25 @@
+export const SAFE_ROUTE_SEGMENT = /^[A-Za-z0-9._-]+$/
+
+/**
+ * Checks that a value is a single path segment, i.e. it cannot walk out of the
+ * directory it gets joined into. Non-ASCII names are allowed, some content
+ * files use them.
+ * @param value - The value taken from a route parameter or content listing
+ * @returns True when the value stays inside its parent directory
+ */
+export const isSinglePathSegment = (value: string): boolean =>
+  value.length > 0 &&
+  value !== '.' &&
+  value !== '..' &&
+  !value.includes('/') &&
+  !value.includes('\\') &&
+  !value.includes('\0')
+
+/**
+ * Stricter variant of isSinglePathSegment that only accepts the plain ASCII
+ * names used by routes rendered as static files.
+ * @param value - The value taken from a route parameter or content listing
+ * @returns True when the value is safe to use as one path segment
+ */
+export const isSafeSegment = (value: string): boolean =>
+  SAFE_ROUTE_SEGMENT.test(value) && isSinglePathSegment(value)

--- a/libs/wordle.ts
+++ b/libs/wordle.ts
@@ -1,6 +1,8 @@
 import path from 'path'
 import fs from 'fs/promises'
 
+import { isSafeSegment } from './utils'
+
 export interface ResultKey {
   id: string
   title: string
@@ -30,13 +32,26 @@ export const englishResults = async () => {
   )
 }
 
-export const englishResult = async (date: string) => {
-  const content = await fs.readFile(
-    path.join(process.cwd(), 'contents', 'wordle', 'en', `${date}.json`),
-    'utf-8'
-  )
-  return {
-    ...JSON.parse(content),
-    id: date
-  } as Result
+export const englishResult = async (date: string): Promise<Result | null> => {
+  if (!isSafeSegment(date)) {
+    return null
+  }
+
+  const file = path.join(process.cwd(), 'contents', 'wordle', 'en', `${date}.json`)
+  let content: string
+  try {
+    content = await fs.readFile(file, 'utf-8')
+  } catch {
+    return null
+  }
+
+  try {
+    return {
+      ...JSON.parse(content),
+      id: date
+    } as Result
+  } catch (error) {
+    console.warn(`Unable to parse wordle result ${file}`, error)
+    return null
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "yarn feeds && next build --turbopack",
     "lint": "eslint . --max-warnings 0",
     "typecheck": "tsc --noEmit",
-    "export": "BLOG_EXPORT=1 next build --turbopack",
+    "export": "yarn feeds && BLOG_EXPORT=1 next build --turbopack",
+    "feeds": "yarn ride:exec scripts/generate-feeds.ts",
     "optimize-images": "scripts/optimize-images.sh",
     "ride:exec": "node --import @swc-node/register/esm-register",
     "ride": "yarn ride:exec scripts/load-netherlands-activities.ts && yarn ride:exec scripts/load-slovenia-activities.ts && yarn ride:exec scripts/simplify-gps.ts && yarn ride:exec scripts/generate-rides-stats.ts"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://www.llun.me/sitemap.xml

--- a/scripts/generate-feeds.ts
+++ b/scripts/generate-feeds.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env -S node --import @swc-node/register/esm-register
+import 'dotenv-flow/config'
+
+import fs from 'fs/promises'
+import path from 'path'
+
+import {
+  buildFeeds,
+  getAllPosts,
+  getConfig,
+  postDescendingComparison
+} from '../libs/blog'
+
+async function run() {
+  const config = getConfig()
+  const posts = getAllPosts().sort(postDescendingComparison)
+  const { atom, json } = buildFeeds(config, posts)
+
+  const feedsPath = path.join(process.cwd(), 'public', 'feeds')
+  await fs.mkdir(feedsPath, { recursive: true })
+  await Promise.all([
+    fs.writeFile(path.join(feedsPath, 'atom.xml'), atom),
+    // Legacy path, still subscribed to externally and served as Atom
+    fs.writeFile(path.join(feedsPath, 'main'), atom),
+    fs.writeFile(path.join(feedsPath, 'feed.json'), json)
+  ])
+}
+
+run()
+  .then(() => {
+    console.log('done')
+  })
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })


### PR DESCRIPTION
Last of the four PRs from the codebase review. Mostly invisible improvements — the feed change is the one thing visitors could notice.

## ⚠️ Feeds: RSS is retired

`/feeds/atom.xml`, `/feeds/main` and `/feeds/feed.json` keep their **exact current paths**. `/feeds/rss.xml` is no longer produced.

Two things made this need care. First, `/feeds/rss.xml` is live and returning 200 today. Second, the S3 syncs deliberately run without `--delete` — so simply not generating it would leave the old object serving a **permanently frozen feed**, which is worse for a subscriber than a clean 404. The deploy now removes that object explicitly.

Also fixed while in there: `feedLinks.rss2` advertised `/feeds/feed.xml`, a file that was never written.

**The architectural fix**: `generateFeeds` wrote four files into `public/` *as a side effect of rendering the homepage* — a build artifact that depended on whether and when a page happened to render, invisible in the build graph. It's now a pure `buildFeeds()` plus `scripts/generate-feeds.ts`, and `build`/`export` run it first.

I deliberately did **not** convert feeds to route handlers: with `trailingSlash: true` and `output: 'export'` the emitted paths for extension-bearing routes aren't guaranteed to match, and breaking a subscribed URL isn't worth the elegance.

## SEO

There was no sitemap at all, and robots.txt didn't reference one. `app/sitemap.ts` enumerates **122 pages** from the existing content helpers — posts, albums, journeys, ride countries and galleries, tags, Amsterdam calendars — with `lastModified` from existing timestamps.

The 557 wordle pages are excluded on purpose: thin templated content that would be 82% of the file. `/journeys/wordle/` itself is listed.

`export const dynamic = 'force-static'` is required or the export build fails outright — which it did until I added it.

## Error pages

Neither route group had a 404 or an error boundary, so the `notFound()` calls in the post and journey routes fell through to Next's bare default. Both groups now have `not-found.tsx` and `error.tsx` (client, with `reset()`). Since there's no root `app/layout.tsx`, these are per-group.

Note: serving a custom 404 for *arbitrary unknown* URLs is still S3/CloudFront error-document configuration, outside this repo.

## Accessibility

- **Nav links had no accessible name on mobile.** `.nav-link-text` is `display:none` below 1024px, which removes it from the accessibility tree too — so all six links were unnamed on phones. Now aria-labelled; verified at 390px that the text is hidden *and* the name survives.
- **Gallery thumbnails were clickable `<div>`s** — keyboard-unreachable and unannounced, and that's the core interaction of the gallery. Now real `<button>`s named from the media caption. The infinite-scroll sentinel ref still lands on the same element, which I verified end-to-end (48 → 72 on scroll).
- **The theme menu claimed `role="menu"` + `menuitemradio`** without any of the keyboard behaviour that contract requires — no arrow keys, no roving tabindex — which is worse for a screen reader than not claiming it. Replaced with a labelled group of `aria-pressed` toggle buttons, which Tab already handles correctly. Escape closes it and restores focus to the trigger.
- **Hover and selected were pixel-identical** in the theme menu (both resolve to `bg-accent`), so hovering an unselected row looked selected. The selected row now carries a ring and weight as well.
- Modal images were all `alt="Detail image"` despite `Media` carrying a real caption.
- The icon-only ride gallery link got the aria-label its sibling already had.

## Performance and robustness

`Header` and `RideVideos` were client components with no hooks or browser APIs. `getPost` ran twice per post per build (metadata + page), re-reading and re-rendering markdown each time — now memoized on a key that can't collide for catch-all segments (`['a/b']` vs `['a','b']` hashed identically with a naive `join('/')`). Gallery thumbnails lazy-load.

`libs/utils.ts` was a zero-byte file; it now holds the segment guard that was previously inline in one page, applied to the route-derived strings the content helpers join into filesystem paths without validation. Parse failures `console.warn` instead of silently dropping content. The Apple proxy host is configurable via `NEXT_PUBLIC_API_HOST`. `Meta.tsx` derives its URLs from config instead of a hardcoded `https://llun.me` that disagreed with the `www` default used everywhere else.

## Verification

Lint, typecheck and both build targets pass, producing the same 682 pages plus `sitemap.xml`. Browser runs against the built export: **map 13/13**, **gallery 6/6** (including the failure guard from #30 still behaving), and **10/10 accessibility assertions**. The modal alt was re-checked in dev, where photos actually load, and reads a caption-derived value rather than the placeholder.

Confirmed the feed and sitemap origin falls back to `https://www.llun.me` when no `.env.local` is present, which is how CI builds — the local `localhost:3000` output is only my machine.

Unrelated and still open: two published posts embed the **old** Mapbox token, which now 403s on tilesets, so those maps render blank on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)